### PR TITLE
Metadata driven schema handling

### DIFF
--- a/src/main/java/com/lucidworks/spark/SchemaPreservingSolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SchemaPreservingSolrRDD.java
@@ -25,9 +25,6 @@ import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.sql.Row;
 
-import scala.Tuple2;
-
-
 public class SchemaPreservingSolrRDD extends SolrRDD {
   public static Logger log = Logger.getLogger(SolrRDD.class);
 
@@ -125,8 +122,8 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
       }
     }).mapToPair(new PairFunction<SolrDocument, String, SolrDocument>() {
       @Override
-      public Tuple2<String, SolrDocument> call(SolrDocument solrDocument){
-        return new Tuple2<String, SolrDocument>(solrDocument.get("id").toString(), solrDocument);
+      public scala.Tuple2<String, SolrDocument> call(SolrDocument solrDocument){
+        return new scala.Tuple2<String, SolrDocument>(solrDocument.get("id").toString(), solrDocument);
       }
     });
     final Map<String, SolrDocument> childMap = childdocs.collectAsMap();

--- a/src/main/java/com/lucidworks/spark/SchemaPreservingSolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SchemaPreservingSolrRDD.java
@@ -26,7 +26,6 @@ import org.apache.spark.sql.types.*;
 import org.apache.spark.sql.Row;
 
 import scala.Tuple2;
-import scala.collection.immutable.Map;
 
 
 public class SchemaPreservingSolrRDD extends SolrRDD {
@@ -40,7 +39,7 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
     super(zkHost, collection, null);
   }
 
-  public SchemaPreservingSolrRDD(String zkHost, String collection, Map<String,String> config) {
+  public SchemaPreservingSolrRDD(String zkHost, String collection, scala.collection.immutable.Map<String,String> config) {
       super(zkHost, collection, config);
   }
   
@@ -60,7 +59,7 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
   public static StructField recurseReadSchema(SolrDocument doc, SolrClient solr, List<StructField> fldr, String collection) throws IOException, SolrServerException {
     Boolean recurse = true;
     String finalName = null;
-    for (java.util.Map.Entry<String, Object> field : doc.entrySet()) {
+    for (Map.Entry<String, Object> field : doc.entrySet()) {
       String name = field.getKey();
       Object value = field.getValue();
       if (name.startsWith("links")) {
@@ -130,7 +129,7 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
         return new Tuple2<String, SolrDocument>(solrDocument.get("id").toString(), solrDocument);
       }
     });
-    final java.util.Map<String, SolrDocument> childMap = childdocs.collectAsMap();
+    final Map<String, SolrDocument> childMap = childdocs.collectAsMap();
     JavaRDD<Row> rows = rootdocs.map(new Function<SolrDocument, Row>() {
       @Override
       public Row call(SolrDocument solrDocument) throws Exception {
@@ -141,14 +140,14 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
     return rows;
   }
 
-  public Row readData(SolrDocument doc, StructType st, String collection, java.util.Map<String, SolrDocument> childMap) throws IOException, SolrServerException {
+  public Row readData(SolrDocument doc, StructType st, String collection, Map<String, SolrDocument> childMap) throws IOException, SolrServerException {
     ArrayList<Object> str = new ArrayList<Object>();
     return recurseDataRead(doc , str, st, collection, childMap);
   }
 
-  public Row recurseDataRead(SolrDocument doc, ArrayList<Object> x, StructType st, String collection, java.util.Map<String, SolrDocument> childMap) {
+  public Row recurseDataRead(SolrDocument doc, ArrayList<Object> x, StructType st, String collection, Map<String, SolrDocument> childMap) {
     Boolean recurse = true;
-    java.util.Map<String, Object> x1 = doc.getFieldValueMap();
+    Map<String, Object> x1 = doc.getFieldValueMap();
     String[] x3 = st.fieldNames();
     Object[] x2 = x1.keySet().toArray();
     for (int i = 0; i < x2.length; i++) {
@@ -438,11 +437,11 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
     int level = 0;
     Iterator it = uniqueIdentifier.entrySet().iterator();
     while (it.hasNext()) {
-      java.util.Map.Entry pair = (java.util.Map.Entry)it.next();
+      Map.Entry pair = (Map.Entry)it.next();
       s.addField(pair.getKey().toString(), pair.getValue());
     }
     if (!s.containsKey("id")){
-      String id = java.util.UUID.randomUUID().toString();
+      String id = UUID.randomUUID().toString();
       s.addField("id",id);
     }
     s.addField("__lwroot_s", "root");
@@ -456,11 +455,11 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
         SolrInputDocument solrDocument = new SolrInputDocument();
         Iterator it = uniqueIdentifier.entrySet().iterator();
         while (it.hasNext()) {
-          java.util.Map.Entry pair = (java.util.Map.Entry)it.next();
+          Map.Entry pair = (Map.Entry)it.next();
           solrDocument.addField(pair.getKey().toString(), pair.getValue());
         }
         if (!solrDocument.containsKey("id")) {
-          String idData = java.util.UUID.randomUUID().toString();
+          String idData = UUID.randomUUID().toString();
           solrDocument.addField("id", idData);
         }
         solrDocument.addField("__lwroot_s", "root");
@@ -482,7 +481,7 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
       if (sf.dataType().typeName().toString().toLowerCase().equals("struct")){
         linkCount = linkCount + 1;
         SolrInputDocument sc = new SolrInputDocument();
-        String id = java.util.UUID.randomUUID().toString();
+        String id = UUID.randomUUID().toString();
         sc.addField("id",id);
         s.addField("links"+linkCount +"_s", id);
         l = l + 1;
@@ -508,7 +507,7 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
       if (sf.dataType().typeName().toString().toLowerCase().equals("struct")) {
         linkCount = linkCount + 1;
         SolrInputDocument solrDocument1 = new SolrInputDocument();
-        String idChild = java.util.UUID.randomUUID().toString();
+        String idChild = UUID.randomUUID().toString();
         solrDocument1.addField("id", idChild);
         solrDocument.addField("links" + linkCount + "_s", idChild);
         solrDocument1.addField("__lwchilddocname_s", sf.name());

--- a/src/main/java/com/lucidworks/spark/SolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SolrRDD.java
@@ -739,6 +739,14 @@ public class SolrRDD implements Serializable {
         solrQuery.setStart(startIndex);
       }
 
+      Integer rows = solrQuery.getRows();
+      if (rows == null)
+          solrQuery.setRows(DEFAULT_PAGE_SIZE);
+      
+      List<SolrQuery.SortClause> sorts = solrQuery.getSorts();
+      if (sorts == null || sorts.isEmpty())
+          solrQuery.addSort(SolrQuery.SortClause.asc(uniqueKey));
+      
       if (callback != null) {
         resp = solrServer.queryAndStreamResponse(solrQuery, callback);
       } else {

--- a/src/main/java/com/lucidworks/spark/SolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SolrRDD.java
@@ -731,9 +731,9 @@ public class SolrRDD implements Serializable {
       java.util.Map<String,SolrFieldMeta> schemaFieldMap = new HashMap<String,SolrFieldMeta>();
       try {
           try {
-              Map<String, Object> adminMeta = SolrJsonSupport.getJson(SolrJsonSupport.getHttpClient(), lukeUrl, 2);
-              Map<String, Object> fieldsMap = SolrJsonSupport.asMap("/fields", adminMeta);
-              Set<String> fieldNamesSet = fieldsMap.keySet();
+              java.util.Map<String, Object> adminMeta = SolrJsonSupport.getJson(SolrJsonSupport.getHttpClient(), lukeUrl, 2);
+              java.util.Map<String, Object> fieldsMap = SolrJsonSupport.asMap("/fields", adminMeta);
+              java.util.Set<String> fieldNamesSet = fieldsMap.keySet();
               schemaFieldMap = getFieldTypes(fieldNamesSet.toArray(new String[fieldNamesSet.size()]), solrBaseUrl, collection);
           } catch (SolrException solrExc) {
               log.warn("Can't get field type for field " + collection+" due to: "+solrExc);
@@ -744,9 +744,9 @@ public class SolrRDD implements Serializable {
       return schemaFieldMap;
   }
 
-  private static Map<String,SolrFieldMeta> getFieldTypes(String[] fields, String solrBaseUrl, String collection) {
+  private static java.util.Map<String,SolrFieldMeta> getFieldTypes(String[] fields, String solrBaseUrl, String collection) {
     // collect mapping of Solr field to type
-    Map<String,SolrFieldMeta> fieldTypeMap = new HashMap<String,SolrFieldMeta>();
+    java.util.Map<String,SolrFieldMeta> fieldTypeMap = new HashMap<String,SolrFieldMeta>();
     for (String field : fields) {
       if (fieldTypeMap.containsKey(field))
         continue;
@@ -769,7 +769,7 @@ public class SolrRDD implements Serializable {
         }
 
         if (tvc == null || tvc.fieldType == null) {
-          String errMsg = "Can't figure out field type for field: " + fieldName + ". Check you Solr schema and retry.";
+          String errMsg = "Can't figure out field type for field: " + field + ". Check you Solr schema and retry.";
           log.error(errMsg);
           throw new RuntimeException(errMsg);
         }
@@ -780,7 +780,7 @@ public class SolrRDD implements Serializable {
         tvc.fieldTypeClass = SolrJsonSupport.asString("/fieldType/class", fieldTypeMeta);
 
       } catch (Exception exc) {
-        String errMsg = "Can't get field type for field " + fieldName + " due to: " + exc;
+        String errMsg = "Can't get field type for field " + field + " due to: " + exc;
         log.error(errMsg);
         if (exc instanceof RuntimeException) {
           throw (RuntimeException)exc;

--- a/src/main/java/com/lucidworks/spark/SolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SolrRDD.java
@@ -42,8 +42,6 @@ import org.apache.spark.sql.DataFrame;
 import org.apache.spark.sql.types.*;
 import org.apache.spark.sql.Row;
 
-import scala.Option;
-
 public class SolrRDD implements Serializable {
 
   public static Logger log = Logger.getLogger(SolrRDD.class);
@@ -212,7 +210,7 @@ public class SolrRDD implements Serializable {
   }
 
     protected static String optionalParam(scala.collection.immutable.Map<String,String> config, String param, String defaultValue) {
-      Option opt = config.get(param);
+      scala.Option<String> opt = config.get(param);
       String val = (opt != null && !opt.isEmpty()) ? (String)opt.get() : null;
       return (val == null || val.trim().isEmpty()) ? defaultValue : val;
     }

--- a/src/main/java/com/lucidworks/spark/SolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SolrRDD.java
@@ -598,6 +598,13 @@ public class SolrRDD implements Serializable {
         Object[] vals = new Object[fields.length];
         for (int f = 0; f < fields.length; f++) {
           StructField field = fields[f];
+          Metadata meta = field.metadata();
+          if (meta != null) {
+              String fieldName = meta.contains("name") ? meta.getString("name") : field.name();
+              Boolean isMultiValued = meta.contains("multiValued") ? meta.getBoolean("multiValued") : false;
+              Boolean isDocValues = meta.contains("docValues") ? meta.getBoolean("docValues") : false;
+              Boolean isStored = meta.contains("stored") ? meta.getBoolean("stored") : false;
+          }
           Object fieldValue = doc.getFieldValue(field.name());
           if (fieldValue != null) {
             if (fieldValue instanceof Collection) {
@@ -630,7 +637,7 @@ public class SolrRDD implements Serializable {
 
     List<StructField> listOfFields = new ArrayList<StructField>();
     for (Map.Entry<String, SolrFieldMeta> field : fieldTypeMap.entrySet()) {
-      String fieldName = field.getKey().replaceAll("\\.","_");
+      String fieldName = field.getKey();
       SolrFieldMeta fieldMeta = field.getValue();
       MetadataBuilder metadata = new MetadataBuilder();
       metadata.putString("name", field.getKey());
@@ -647,7 +654,7 @@ public class SolrRDD implements Serializable {
       if (fieldMeta.fieldType != null) metadata.putString("type", fieldMeta.fieldType);
       if (fieldMeta.dynamicBase != null) metadata.putString("dynamicBase", fieldMeta.dynamicBase);
       if (fieldMeta.fieldTypeClass != null) metadata.putString("class", fieldMeta.fieldTypeClass);
-      listOfFields.add(DataTypes.createStructField(fieldName, dataType, !fieldMeta.isRequired, metadata.build()));
+      listOfFields.add(DataTypes.createStructField(fieldName.replaceAll("\\.","_"), dataType, !fieldMeta.isRequired, metadata.build()));
     }
 
     return DataTypes.createStructType(listOfFields);

--- a/src/main/java/com/lucidworks/spark/SolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SolrRDD.java
@@ -579,7 +579,7 @@ public class SolrRDD implements Serializable {
               Boolean isMultiValued = meta.contains("multiValued") ? meta.getBoolean("multiValued") : false;
               Boolean isDocValues = meta.contains("docValues") ? meta.getBoolean("docValues") : false;
               Boolean isStored = meta.contains("stored") ? meta.getBoolean("stored") : false;
-              if (!isMultiValued && isDocValues && !isStored) {
+              if (isDocValues) {
                   fieldList[f] = field.name() + ":field("+fieldName+")";
               } else {
                   fieldList[f] = field.name() + ":" + fieldName;
@@ -599,13 +599,11 @@ public class SolrRDD implements Serializable {
         for (int f = 0; f < fields.length; f++) {
           StructField field = fields[f];
           Metadata meta = field.metadata();
-          if (meta != null) {
-              String fieldName = meta.contains("name") ? meta.getString("name") : field.name();
-              Boolean isMultiValued = meta.contains("multiValued") ? meta.getBoolean("multiValued") : false;
-              Boolean isDocValues = meta.contains("docValues") ? meta.getBoolean("docValues") : false;
-              Boolean isStored = meta.contains("stored") ? meta.getBoolean("stored") : false;
-          }
-          Object fieldValue = doc.getFieldValue(field.name());
+          String fieldName = meta.contains("name") ? meta.getString("name") : field.name();
+          Boolean isMultiValued = meta.contains("multiValued") ? meta.getBoolean("multiValued") : false;
+          Boolean isDocValues = meta.contains("docValues") ? meta.getBoolean("docValues") : false;
+          Boolean isStored = meta.contains("stored") ? meta.getBoolean("stored") : false;
+          Object fieldValue = isMultiValued ? doc.getFieldValues(field.name()) : doc.getFieldValue(field.name());;
           if (fieldValue != null) {
             if (fieldValue instanceof Collection) {
               vals[f] = ((Collection) fieldValue).toArray();
@@ -723,7 +721,7 @@ public class SolrRDD implements Serializable {
         Map<String, Object> fieldTypeMeta =
           SolrJsonSupport.getJson(SolrJsonSupport.getHttpClient(), fieldTypeUrl, 2);
 
-            tvc.fieldTypeClass = SolrJsonSupport.asString("/fieldType/class", fieldTypeMeta);
+        tvc.fieldTypeClass = SolrJsonSupport.asString("/fieldType/class", fieldTypeMeta);
 
       } catch (Exception exc) {
         String errMsg = "Can't get field type for field " + field + " due to: " + exc;

--- a/src/main/java/com/lucidworks/spark/SolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SolrRDD.java
@@ -755,7 +755,7 @@ public class SolrRDD implements Serializable {
       SolrFieldMeta tvc = null;
       try {
         try {
-          Map<String, Object> fieldMeta =
+          java.util.Map<String, Object> fieldMeta =
             SolrJsonSupport.getJson(SolrJsonSupport.getHttpClient(), fieldUrl, 2);
           tvc = new SolrFieldMeta();
           tvc.fieldType = SolrJsonSupport.asString("/field/type", fieldMeta);
@@ -769,7 +769,7 @@ public class SolrRDD implements Serializable {
         }
 
         if (tvc == null || tvc.fieldType == null) {
-          String errMsg = "Can't figure out field type for field: " + field + ". Check you Solr schema and retry.";
+          String errMsg = "Can't figure out field type for field: " + fieldName + ". Check you Solr schema and retry.";
           log.error(errMsg);
           throw new RuntimeException(errMsg);
         }
@@ -780,7 +780,7 @@ public class SolrRDD implements Serializable {
         tvc.fieldTypeClass = SolrJsonSupport.asString("/fieldType/class", fieldTypeMeta);
 
       } catch (Exception exc) {
-        String errMsg = "Can't get field type for field " + field + " due to: " + exc;
+        String errMsg = "Can't get field type for field " + fieldName + " due to: " + exc;
         log.error(errMsg);
         if (exc instanceof RuntimeException) {
           throw (RuntimeException)exc;
@@ -788,7 +788,6 @@ public class SolrRDD implements Serializable {
           throw new RuntimeException(errMsg, exc);
         }
       }
-      disableMultiValued && tvc.isMultiValued && tvc.isDocValues
       if (tvc != null && (tvc.isStored || (tvc.isDocValues && !disableMultiValued && tvc.isMultiValued))) {
         fieldTypeMap.put(field, tvc);
       } else {
@@ -812,14 +811,14 @@ public class SolrRDD implements Serializable {
     }
 
     Collections.sort(values);
-    final Map<String,Double> labelMap = new HashMap<>();
+    final HashMap<String, Double> labelMap = new HashMap<String, Double>();
     double d = 0d;
     for (String label : values) {
       labelMap.put(label, new Double(d));
       d += 1d;
     }
 
-    return labelMap;
+    return (Map<String, Double>) labelMap;
   }
 
   public static QueryResponse querySolr(SolrClient solrServer, SolrQuery solrQuery, int startIndex, String cursorMark) throws SolrServerException {

--- a/src/main/java/com/lucidworks/spark/SolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SolrRDD.java
@@ -6,7 +6,6 @@ import java.net.ConnectException;
 import java.net.SocketException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.Map.Entry;
 
 import com.lucidworks.spark.query.*;
 import com.lucidworks.spark.util.SolrJsonSupport;
@@ -695,7 +694,7 @@ public class SolrRDD implements Serializable {
       if (tvc != null && (tvc.isStored || tvc.isDocValues)) {
         fieldTypeMap.put(field, tvc);
       } else {
-         log.warn("Can't retrieve an index only field: " + fieldName);
+         log.warn("Can't retrieve an index only field: " + field);
       }
     }
 

--- a/src/main/java/com/lucidworks/spark/SolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SolrRDD.java
@@ -788,10 +788,16 @@ public class SolrRDD implements Serializable {
           throw new RuntimeException(errMsg, exc);
         }
       }
-      if (tvc != null && (tvc.isStored || (tvc.isDocValues && !disableMultiValued && tvc.isMultiValued))) {
+      if (!(tvc.isStored || tvc.isDocValues)) {
+        log.warn("Can't retrieve an index only field: " + field);
+        tvc = null;
+      }
+      if (disableMultiValued && tvc.isMultiValued && tvc.isDocValues) {
+        log.warn("Can't retrieve a multiValued docValues field: " + field);
+        tvc = null;
+      }
+      if (tvc != null) {
         fieldTypeMap.put(field, tvc);
-      } else {
-         log.warn("Can't retrieve an index only field: " + field);
       }
     }
 

--- a/src/main/java/com/lucidworks/spark/SolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SolrRDD.java
@@ -212,7 +212,7 @@ public class SolrRDD implements Serializable {
     ModifiableSolrParams params = new ModifiableSolrParams();
     params.set("collection", collection);
     params.set("qt", "/get");
-    params.set(uniqueKey, docId);
+    params.set("id", docId);
     QueryResponse resp = null;
     try {
       resp = cloudSolrServer.query(params);

--- a/src/main/java/com/lucidworks/spark/SolrRelation.java
+++ b/src/main/java/com/lucidworks/spark/SolrRelation.java
@@ -207,13 +207,11 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
           Boolean isMultiValued = meta.contains("multiValued") ? meta.getBoolean("multiValued") : false;
           Boolean isDocValues = meta.contains("docValues") ? meta.getBoolean("docValues") : false;
           Boolean isStored = meta.contains("stored") ? meta.getBoolean("stored") : false;
-          if (isStored || isDocValues) {
+          if (isStored || (isDocValues && !isMultiValued)) {
               fieldList.add(schemaField.name());
           }
       }
-      String[] fieldArr = new String[fieldList.size()];
-      fieldArr = fieldList.toArray(fieldArr);
-      solrQuery.setFields(fieldArr);
+      solrQuery.setFields(fieldList.toArray(new String[fieldList.size()]));
   }
   
   protected void applyFilter(Filter filter) {

--- a/src/main/java/com/lucidworks/spark/SolrRelation.java
+++ b/src/main/java/com/lucidworks/spark/SolrRelation.java
@@ -241,7 +241,7 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
           Boolean isMultiValued = meta.contains("multiValued") ? meta.getBoolean("multiValued") : false;
           Boolean isDocValues = meta.contains("docValues") ? meta.getBoolean("docValues") : false;
           Boolean isStored = meta.contains("stored") ? meta.getBoolean("stored") : false;
-          if (!isMultiValued && (isDocValues || isStored)) {
+          if (isStored || (!isMultiValued && isDocValues)) {
               fieldList.add(schemaField.name());
           }
       }

--- a/src/main/java/com/lucidworks/spark/SolrRelation.java
+++ b/src/main/java/com/lucidworks/spark/SolrRelation.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.*;
 
-import scala.Option;
 import scala.collection.JavaConverters;
 
 public class SolrRelation extends BaseRelation implements Serializable, TableScan, PrunedFilteredScan, InsertableRelation {

--- a/src/main/java/com/lucidworks/spark/SolrRelation.java
+++ b/src/main/java/com/lucidworks/spark/SolrRelation.java
@@ -36,29 +36,17 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
 
   public static Logger log = Logger.getLogger(SolrRelation.class);
 
-  public static String SOLR_ZK_HOST_PARAM = "zkhost";
-  public static String SOLR_COLLECTION_PARAM = "collection";
-  public static String SOLR_QUERY_PARAM = "query";
-  public static String SOLR_FIELD_LIST_PARAM = "fields";
-  public static String SOLR_ROWS_PARAM = "rows";
-  public static String SOLR_SPLIT_FIELD_PARAM = "split_field";
-  public static String SOLR_SPLITS_PER_SHARD_PARAM = "splits_per_shard";
-  public static String SOLR_PARALLEL_SHARDS = "parallel_shards";
   protected String[] fieldList;
-  public static String PRESERVE_SCHEMA = "preserveschema";
   protected Boolean preserveSchema = false;
-  protected String splitFieldName;
-  protected int splitsPerShard = 1;
   protected SolrQuery solrQuery;
   protected SolrRDD solrRDD;
   protected StructType schema;
   protected ModifiableSolrParams addlSolrParams;
-  protected boolean parallelShards = true;
   protected transient SQLContext sqlContext;
 
   protected Integer rows = null;
 
-  protected transient JavaSparkContext sc;
+  protected transient JavaSparkContext jsc;
 
   public SolrRelation() {}
 
@@ -72,39 +60,33 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
       throw new IllegalArgumentException("SQLContext cannot be null!");
 
     this.sqlContext = sqlContext;
-    this.sc =  new JavaSparkContext(sqlContext.sparkContext());
-    String preserveSch = optionalParam(config, PRESERVE_SCHEMA, "N");
+    this.jsc = new JavaSparkContext(sqlContext.sparkContext());
+    String preserveSch = SolrRDD.optionalParam(config, SolrRDD.PRESERVE_SCHEMA, "N");
     if ("Y".equals(preserveSch) || Boolean.parseBoolean(preserveSch)) {
       preserveSchema = true;
     };
-    String zkHost = requiredParam(config, SOLR_ZK_HOST_PARAM);
-    String collection = requiredParam(config, SOLR_COLLECTION_PARAM);
-    String query = optionalParam(config, SOLR_QUERY_PARAM, "*:*");
-    String fieldListParam = optionalParam(config, SOLR_FIELD_LIST_PARAM, null);
+    String zkHost = SolrRDD.requiredParam(config, SolrRDD.SOLR_ZK_HOST_PARAM);
+    String collection = SolrRDD.requiredParam(config, SolrRDD.SOLR_COLLECTION_PARAM);
+    String query = SolrRDD.optionalParam(config, SolrRDD.SOLR_QUERY_PARAM, "*:*");
+    String fieldListParam = SolrRDD.optionalParam(config, SolrRDD.SOLR_FIELD_LIST_PARAM, null);
     if (fieldListParam != null) {
       this.fieldList = fieldListParam.split(",");
     } else {
       this.fieldList = null;
     }
-    String rowsParam = optionalParam(config, SOLR_ROWS_PARAM, null);
+    String rowsParam = SolrRDD.optionalParam(config, SolrRDD.SOLR_ROWS_PARAM, null);
     if (rowsParam != null) {
       this.rows = new Integer(rowsParam);
     }
 
-    parallelShards = Boolean.parseBoolean(optionalParam(config, SOLR_PARALLEL_SHARDS, "true"));
-
-    splitFieldName = optionalParam(config, SOLR_SPLIT_FIELD_PARAM, null);
-    if (splitFieldName != null)
-      splitsPerShard = Integer.parseInt(optionalParam(config, SOLR_SPLITS_PER_SHARD_PARAM, "20"));
-
     if (!preserveSchema) {
-      solrRDD = new SolrRDD(zkHost, collection);
+      solrRDD = new SolrRDD(zkHost, collection, config);
     }
     else {
-      solrRDD = new SchemaPreservingSolrRDD(zkHost, collection);
-      solrRDD.setSc(sc);
+      solrRDD = new SchemaPreservingSolrRDD(zkHost, collection, config);
+      solrRDD.setSc(jsc);
     }
-
+    
     solrQuery = SolrRDD.toQuery(query);
 
     if (fieldList != null) {
@@ -137,24 +119,16 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
     solrQuery.add(addlSolrParams);
 
     solrQuery.set("collection", collection);
+
     if (dataFrame != null) {
       schema = dataFrame.schema();
+    } else if (fieldList != null) {
+      schema = deriveQuerySchema(fieldList);
     } else {
-      schema = solrRDD.getQuerySchema(solrQuery);
+      schema = solrRDD.getSchema();
     }
   }
 
-  protected String optionalParam(Map<String,String> config, String param, String defaultValue) {
-    Option opt = config.get(param);
-    String val = (opt != null && !opt.isEmpty()) ? (String)opt.get() : null;
-    return (val == null || val.trim().isEmpty()) ? defaultValue : val;
-  }
-
-  protected String requiredParam(Map<String,String> config, String param) {
-    String val = optionalParam(config, param, null);
-    if (val == null) throw new IllegalArgumentException(param+" parameter is required!");
-    return val;
-  }
 
   public SolrQuery getQuery() {
     return solrQuery;
@@ -209,8 +183,7 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
 
       // build the schema based on the desired fields - applicable only for non-schemapreserving dataframes in solr
       StructType querySchema = (fields != null && fields.length > 0 && !preserveSchema) ? deriveQuerySchema(fields) : schema;
-      JavaRDD<SolrDocument> docs = parallelShards ?
-              solrRDD.queryShards(sc, solrQuery, splitFieldName, splitsPerShard) : solrRDD.queryDeep(sc, solrQuery);
+      JavaRDD<SolrDocument> docs = solrRDD.query(jsc, solrQuery);
       rows = solrRDD.toRows(querySchema, docs).rdd();
     } catch (Exception e) {
       if (e instanceof RuntimeException) {
@@ -226,14 +199,14 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
   // derive a schema for a specific query from the full collection schema
   protected StructType deriveQuerySchema(String[] fields) {
     java.util.Map<String,StructField> fieldMap = new HashMap<String,StructField>();
-    for (StructField f : schema.fields()) fieldMap.put(f.name(), f);
+    for (StructField f : solrRDD.getSchema().fields()) fieldMap.put(f.name(), f);
     List<StructField> listOfFields = new ArrayList<StructField>();
     for (String field : fields) listOfFields.add(fieldMap.get(field));
     return DataTypes.createStructType(listOfFields);
   }
 
   protected void applyDefaultFields() {
-      StructField[] schemaFields = schema.fields();
+      StructField[] schemaFields = solrRDD.getSchema().fields();
       List<String> fieldList = new ArrayList<String>();
       for (int sf = 0; sf < schemaFields.length; sf++) {
           StructField schemaField = schemaFields[sf];
@@ -241,7 +214,7 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
           Boolean isMultiValued = meta.contains("multiValued") ? meta.getBoolean("multiValued") : false;
           Boolean isDocValues = meta.contains("docValues") ? meta.getBoolean("docValues") : false;
           Boolean isStored = meta.contains("stored") ? meta.getBoolean("stored") : false;
-          if (isStored || (!isMultiValued && isDocValues)) {
+          if (isStored || isDocValues) {
               fieldList.add(schemaField.name());
           }
       }
@@ -268,8 +241,8 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
   
   protected String attributeToFieldName(String attribute) {
       java.util.Map<String,StructField> fieldMap = new HashMap<String,StructField>();
-      for (StructField f : schema.fields()) fieldMap.put(f.name(), f);
-      StructField field = fieldMap.get(attribute);
+      for (StructField f : solrRDD.getSchema().fields()) fieldMap.put(f.name(), f);
+      StructField field = fieldMap.get(attribute.replaceAll("`",""));
       if (field != null) {
           Metadata meta = field.metadata();
           String fieldName = meta.contains("name") ? meta.getString("name") : field.name();

--- a/src/main/java/com/lucidworks/spark/SolrRelation.java
+++ b/src/main/java/com/lucidworks/spark/SolrRelation.java
@@ -21,16 +21,10 @@ import org.apache.spark.sql.types.StructType;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 
 import scala.Option;
 import scala.collection.JavaConverters;
-import scala.collection.immutable.Map;
 
 public class SolrRelation extends BaseRelation implements Serializable, TableScan, PrunedFilteredScan, InsertableRelation {
 
@@ -50,11 +44,11 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
 
   public SolrRelation() {}
 
-  public SolrRelation(SQLContext sqlContext, Map<String,String> config) throws Exception {
+  public SolrRelation(SQLContext sqlContext, scala.collection.immutable.Map<String,String> config) throws Exception {
     this(sqlContext, config, null);
   }
 
-  public SolrRelation(SQLContext sqlContext, Map<String,String> config, DataFrame dataFrame) throws Exception {
+  public SolrRelation(SQLContext sqlContext, scala.collection.immutable.Map<String,String> config, DataFrame dataFrame) throws Exception {
 
     if (sqlContext == null)
       throw new IllegalArgumentException("SQLContext cannot be null!");
@@ -103,7 +97,7 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
     // start with solr. to pass to the query as additional params,
     // but skip the q and fl as they are first-class options for this relation
     addlSolrParams = new ModifiableSolrParams();
-    java.util.Map<String,String> configMap = JavaConverters.asJavaMapConverter(config).asJava();
+    Map<String,String> configMap = JavaConverters.asJavaMapConverter(config).asJava();
     for (String key : configMap.keySet()) {
       if (key.startsWith("solr.")) {
         String param = key.substring(5);
@@ -198,7 +192,7 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
 
   // derive a schema for a specific query from the full collection schema
   protected StructType deriveQuerySchema(String[] fields) {
-    java.util.Map<String,StructField> fieldMap = new HashMap<String,StructField>();
+    Map<String,StructField> fieldMap = new HashMap<String,StructField>();
     for (StructField f : solrRDD.getSchema().fields()) fieldMap.put(f.name(), f);
     List<StructField> listOfFields = new ArrayList<StructField>();
     for (String field : fields) listOfFields.add(fieldMap.get(field));
@@ -240,7 +234,7 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
   }
   
   protected String attributeToFieldName(String attribute) {
-      java.util.Map<String,StructField> fieldMap = new HashMap<String,StructField>();
+      Map<String,StructField> fieldMap = new HashMap<String,StructField>();
       for (StructField f : solrRDD.getSchema().fields()) fieldMap.put(f.name(), f);
       StructField field = fieldMap.get(attribute.replaceAll("`",""));
       if (field != null) {

--- a/src/main/java/com/lucidworks/spark/example/query/KMeansAnomaly.java
+++ b/src/main/java/com/lucidworks/spark/example/query/KMeansAnomaly.java
@@ -75,9 +75,9 @@ public class KMeansAnomaly implements SparkApp.RDDProcessor {
     options.put("zkhost", zkHost);
     options.put("collection", collection);
     options.put("query", queryStr);
-    options.put(SolrRelation.SOLR_SPLIT_FIELD_PARAM, "_version_");
-    options.put(SolrRelation.SOLR_SPLITS_PER_SHARD_PARAM, "4");
-    options.put(SolrRelation.SOLR_FIELD_LIST_PARAM, "id,_version_,"+UID_FIELD+","+TS_FIELD+",bytes_s,response_s,verb_s");
+    options.put(SolrRDD.SOLR_SPLIT_FIELD_PARAM, "_version_");
+    options.put(SolrRDD.SOLR_SPLITS_PER_SHARD_PARAM, "4");
+    options.put(SolrRDD.SOLR_FIELD_LIST_PARAM, "id,_version_,"+UID_FIELD+","+TS_FIELD+",bytes_s,response_s,verb_s");
 
     // Use the Solr DataSource to load rows from a Solr collection using a query
     // highlights include:

--- a/src/test/java/com/lucidworks/spark/SolrRelationTest.java
+++ b/src/test/java/com/lucidworks/spark/SolrRelationTest.java
@@ -91,8 +91,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
 
     String zkHost = cluster.getZkServer().getZkAddress();
     Map<String, String> options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, testCollection);
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, testCollection);
     sourceData.write().format(DefaultSource.SOLR_FORMAT).options(options).mode(SaveMode.Overwrite).save();
     Thread.sleep(1000);
 
@@ -102,7 +102,7 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     dumpSolrCollection(testCollection, q);
 
     // now read the data back from Solr and validate that it was saved correctly and that all data type handling is correct
-    options.put(SolrRelation.SOLR_FIELD_LIST_PARAM, array2cdl(cols));
+    options.put(SolrRDD.SOLR_FIELD_LIST_PARAM, array2cdl(cols));
     DataFrame fromSolr = sqlContext.read().format(DefaultSource.SOLR_FORMAT).options(options).load();
     fromSolr = fromSolr.sort("id");
     fromSolr.printSchema();
@@ -149,8 +149,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     buildCollection(zkHost, testCollection, testData, 2);
 
     Map<String, String> options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, testCollection);
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, testCollection);
 
     DataFrame df = sqlContext.read().format("solr").options(options).load();
 
@@ -209,8 +209,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     createCollection("testFilterSupport2", numShards, replicationFactor, 2, confName, confDir);
 
     options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, "testFilterSupport2");
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, "testFilterSupport2");
 
     df.write().format("solr").options(options).mode(SaveMode.Overwrite).save();
     Thread.sleep(1000);
@@ -253,8 +253,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     HashMap<String, String> options = new HashMap<String, String>();
     String zkHost = cluster.getZkServer().getZkAddress();
     options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, "testNested");
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, "testNested");
     options.put("preserveschema", "Y");
     df.write().format("solr").options(options).mode(SaveMode.Overwrite).save();
     Thread.sleep(1000);
@@ -307,8 +307,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     DataFrame dfLR = sqlContext.load("LRParquet/data/");
     HashMap<String, String> options = new HashMap<String, String>();
     options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, "TestLR");
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, "TestLR");
     options.put("preserveschema", "Y");
     dfLR.write().format("solr").options(options).mode(SaveMode.Overwrite).save();
     dfLR.show();
@@ -340,9 +340,9 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     DataFrame dfNB = sqlContext.load("NBParquet/data/");
     HashMap<String, String> options = new HashMap<String, String>();
     options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
     options.put("preserveschema", "Y");
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, "TestNB");
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, "TestNB");
     dfNB.write().format("solr").options(options).mode(SaveMode.Overwrite).save();
     dfNB.show();
     Thread.sleep(5000);


### PR DESCRIPTION
My use case for solr is more focused on docValues than stored fields to reduce the fieldCache as much as possible. I also use a mongo _id as the uniqueKey instead of the default field that we instead use just for shard routing since solr is just our index overlay for our primary mongo data store and not being treated as a standalone read/write data store.  I'm planning in a separate branch to include support for the export handler so that the multiValued docValues fields can be accessible (also due to my use case) but I'm not sure if I have to switch to solr.io streaming and therefore require solr 5.x instead of being backwards compatible to 4.10.4  or if I can hack something using the SolrJsonSupport.getJson.