### PR TITLE
Support for null-safe equality comparison (added from Spark 1.5).

### DIFF
--- a/src/main/java/com/lucidworks/spark/SolrRelation.java
+++ b/src/main/java/com/lucidworks/spark/SolrRelation.java
@@ -259,6 +259,10 @@ public class SolrRelation extends BaseRelation implements Serializable, TableSca
       EqualTo eq = (EqualTo)f;
       attr = eq.attribute();
       crit = String.valueOf(eq.value());
+    } else if (f instanceof EqualNullSafe) {
+      EqualNullSafe eq = (EqualNullSafe)f;
+      attr = eq.attribute();
+      crit = String.valueOf(eq.value());
     } else if (f instanceof GreaterThan) {
       GreaterThan gt = (GreaterThan)f;
       attr = gt.attribute();

--- a/src/test/java/com/lucidworks/spark/SolrRelationTest.java
+++ b/src/test/java/com/lucidworks/spark/SolrRelationTest.java
@@ -77,6 +77,9 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     count = df.filter(df.col("field1_s").equalTo("a")).count();
     assertCount(2, count, "field1_s == a");
 
+    count = df.filter(df.col("field1_s").equalTo("a")).count();
+    assertCount(2, count, "field1_s <=> a");
+
     count = df.filter(df.col("field3_i").gt(3000)).count();
     assertCount(1, count, "field3_i > 3000");
 


### PR DESCRIPTION
https://github.com/LucidWorks/spark-solr/issues/20

Simply I added a missing filter which is added for Spark 1.5 and tested passing all the testcodes including one I added.

Spark does not pass `EqualNullSafe` filter having null value but instead `IsNull`. So it is safe to process identically with `EqualTo`.