### PR TITLE
Update pom.xml to include a licenses section

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,14 @@
     <version>1.2.0-SNAPSHOT</version>
     <name>spark-solr</name>
     <url>http://maven.apache.org</url>
+    <licenses>
+        <license>
+            <name>Apache License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>A business-friendly OSS license</comments>
+        </license>
+    </licenses>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.7</java.version>


### PR DESCRIPTION
Update pom.xml to include a licenses section, with the Apache License Version 2.0 per the LICENSE file.

This allows tools like https://github.com/hierynomus/license-gradle-plugin to gather license information automatically.

The content and example comes from https://maven.apache.org/pom.html#Licenses
The position in the XML file is per http://maven.apache.org/xsd/maven-4.0.0.xsd