### PR TITLE
Schema driven unique key with field escaping and docValues support

### DIFF
--- a/src/main/java/com/lucidworks/spark/SchemaPreservingSolrRDD.java
+++ b/src/main/java/com/lucidworks/spark/SchemaPreservingSolrRDD.java
@@ -22,21 +22,23 @@ import org.apache.spark.api.java.function.PairFunction;
 import org.apache.spark.mllib.linalg.*;
 import org.apache.spark.sql.DataFrame;
 import org.apache.spark.sql.RowFactory;
-
 import org.apache.spark.sql.types.*;
 import org.apache.spark.sql.Row;
-import scala.Tuple2;
-
 
 public class SchemaPreservingSolrRDD extends SolrRDD {
-  public static Logger log = Logger.getLogger(SolrRDD.class);
+
+  public static Logger log = Logger.getLogger(SchemaPreservingSolrRDD.class);
 
   public SchemaPreservingSolrRDD(String collection) {
     super("localhost:9983", collection); // assume local embedded ZK if not supplied
   }
 
   public SchemaPreservingSolrRDD(String zkHost, String collection) {
-    super(zkHost, collection);
+    super(zkHost, collection, new scala.collection.immutable.HashMap<String,String>());
+  }
+
+  public SchemaPreservingSolrRDD(String zkHost, String collection, scala.collection.immutable.Map<String,String> config) {
+    super(zkHost, collection, config);
   }
 
   @Override
@@ -55,7 +57,7 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
   public static StructField recurseReadSchema(SolrDocument doc, SolrClient solr, List<StructField> fldr, String collection) throws IOException, SolrServerException {
     Boolean recurse = true;
     String finalName = null;
-    for (java.util.Map.Entry<String, Object> field : doc.entrySet()) {
+    for (Map.Entry<String, Object> field : doc.entrySet()) {
       String name = field.getKey();
       Object value = field.getValue();
       if (name.startsWith("links")) {
@@ -121,8 +123,8 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
       }
     }).mapToPair(new PairFunction<SolrDocument, String, SolrDocument>() {
       @Override
-      public Tuple2<String, SolrDocument> call(SolrDocument solrDocument){
-        return new Tuple2<String, SolrDocument>(solrDocument.get("id").toString(), solrDocument);
+      public scala.Tuple2<String, SolrDocument> call(SolrDocument solrDocument){
+        return new scala.Tuple2<String, SolrDocument>(solrDocument.get("id").toString(), solrDocument);
       }
     });
     final Map<String, SolrDocument> childMap = childdocs.collectAsMap();
@@ -143,7 +145,7 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
 
   public Row recurseDataRead(SolrDocument doc, ArrayList<Object> x, StructType st, String collection, Map<String, SolrDocument> childMap) {
     Boolean recurse = true;
-    java.util.Map<String, Object> x1 = doc.getFieldValueMap();
+    Map<String, Object> x1 = doc.getFieldValueMap();
     String[] x3 = st.fieldNames();
     Object[] x2 = x1.keySet().toArray();
     for (int i = 0; i < x2.length; i++) {
@@ -433,11 +435,11 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
     int level = 0;
     Iterator it = uniqueIdentifier.entrySet().iterator();
     while (it.hasNext()) {
-      java.util.Map.Entry pair = (java.util.Map.Entry)it.next();
+      Map.Entry pair = (Map.Entry)it.next();
       s.addField(pair.getKey().toString(), pair.getValue());
     }
     if (!s.containsKey("id")){
-      String id = java.util.UUID.randomUUID().toString();
+      String id = UUID.randomUUID().toString();
       s.addField("id",id);
     }
     s.addField("__lwroot_s", "root");
@@ -451,11 +453,11 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
         SolrInputDocument solrDocument = new SolrInputDocument();
         Iterator it = uniqueIdentifier.entrySet().iterator();
         while (it.hasNext()) {
-          java.util.Map.Entry pair = (java.util.Map.Entry)it.next();
+          Map.Entry pair = (Map.Entry)it.next();
           solrDocument.addField(pair.getKey().toString(), pair.getValue());
         }
         if (!solrDocument.containsKey("id")) {
-          String idData = java.util.UUID.randomUUID().toString();
+          String idData = UUID.randomUUID().toString();
           solrDocument.addField("id", idData);
         }
         solrDocument.addField("__lwroot_s", "root");
@@ -477,7 +479,7 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
       if (sf.dataType().typeName().toString().toLowerCase().equals("struct")){
         linkCount = linkCount + 1;
         SolrInputDocument sc = new SolrInputDocument();
-        String id = java.util.UUID.randomUUID().toString();
+        String id = UUID.randomUUID().toString();
         sc.addField("id",id);
         s.addField("links"+linkCount +"_s", id);
         l = l + 1;
@@ -503,7 +505,7 @@ public class SchemaPreservingSolrRDD extends SolrRDD {
       if (sf.dataType().typeName().toString().toLowerCase().equals("struct")) {
         linkCount = linkCount + 1;
         SolrInputDocument solrDocument1 = new SolrInputDocument();
-        String idChild = java.util.UUID.randomUUID().toString();
+        String idChild = UUID.randomUUID().toString();
         solrDocument1.addField("id", idChild);
         solrDocument.addField("links" + linkCount + "_s", idChild);
         solrDocument1.addField("__lwchilddocname_s", sf.name());

--- a/src/main/java/com/lucidworks/spark/example/query/KMeansAnomaly.java
+++ b/src/main/java/com/lucidworks/spark/example/query/KMeansAnomaly.java
@@ -75,9 +75,9 @@ public class KMeansAnomaly implements SparkApp.RDDProcessor {
     options.put("zkhost", zkHost);
     options.put("collection", collection);
     options.put("query", queryStr);
-    options.put(SolrRelation.SOLR_SPLIT_FIELD_PARAM, "_version_");
-    options.put(SolrRelation.SOLR_SPLITS_PER_SHARD_PARAM, "4");
-    options.put(SolrRelation.SOLR_FIELD_LIST_PARAM, "id,_version_,"+UID_FIELD+","+TS_FIELD+",bytes_s,response_s,verb_s");
+    options.put(SolrRDD.SOLR_SPLIT_FIELD_PARAM, "_version_");
+    options.put(SolrRDD.SOLR_SPLITS_PER_SHARD_PARAM, "4");
+    options.put(SolrRDD.SOLR_FIELD_LIST_PARAM, "id,_version_,"+UID_FIELD+","+TS_FIELD+",bytes_s,response_s,verb_s");
 
     // Use the Solr DataSource to load rows from a Solr collection using a query
     // highlights include:

--- a/src/test/java/com/lucidworks/spark/SolrRelationTest.java
+++ b/src/test/java/com/lucidworks/spark/SolrRelationTest.java
@@ -91,8 +91,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
 
     String zkHost = cluster.getZkServer().getZkAddress();
     Map<String, String> options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, testCollection);
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, testCollection);
     sourceData.write().format(DefaultSource.SOLR_FORMAT).options(options).mode(SaveMode.Overwrite).save();
     Thread.sleep(1000);
 
@@ -102,7 +102,7 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     dumpSolrCollection(testCollection, q);
 
     // now read the data back from Solr and validate that it was saved correctly and that all data type handling is correct
-    options.put(SolrRelation.SOLR_FIELD_LIST_PARAM, array2cdl(cols));
+    options.put(SolrRDD.SOLR_FIELD_LIST_PARAM, array2cdl(cols));
     DataFrame fromSolr = sqlContext.read().format(DefaultSource.SOLR_FORMAT).options(options).load();
     fromSolr = fromSolr.sort("id");
     fromSolr.printSchema();
@@ -149,8 +149,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     buildCollection(zkHost, testCollection, testData, 2);
 
     Map<String, String> options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, testCollection);
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, testCollection);
 
     DataFrame df = sqlContext.read().format("solr").options(options).load();
 
@@ -212,8 +212,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     createCollection("testFilterSupport2", numShards, replicationFactor, 2, confName, confDir);
 
     options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, "testFilterSupport2");
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, "testFilterSupport2");
 
     df.write().format("solr").options(options).mode(SaveMode.Overwrite).save();
     Thread.sleep(1000);
@@ -256,8 +256,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     HashMap<String, String> options = new HashMap<String, String>();
     String zkHost = cluster.getZkServer().getZkAddress();
     options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, "testNested");
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, "testNested");
     options.put("preserveschema", "Y");
     df.write().format("solr").options(options).mode(SaveMode.Overwrite).save();
     Thread.sleep(1000);
@@ -271,6 +271,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
   }
 
   public void createMLModelLRParquet() throws Exception {
+    File lRModel = new File("LRParquet").getAbsoluteFile();
+    if (lRModel.exists()) FileUtils.forceDelete(lRModel);
     List<LabeledPoint> list = new ArrayList<LabeledPoint>();
     LabeledPoint zero = new LabeledPoint(0.0, Vectors.dense(1.0, 0.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0));
     LabeledPoint one = new LabeledPoint(1.0, Vectors.dense(8.0,7.0,6.0,4.0,5.0,6.0,1.0,2.0,3.0));
@@ -284,6 +286,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
   }
 
   public void createMLModelNBParquet() throws Exception {
+    File nBModel = new File("NBParquet").getAbsoluteFile();
+    if (nBModel.exists()) FileUtils.forceDelete(nBModel);
     List<LabeledPoint> list = new ArrayList<LabeledPoint>();
     LabeledPoint zero = new LabeledPoint(0.0, Vectors.dense(1.0, 0.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0));
     LabeledPoint one = new LabeledPoint(1.0, Vectors.dense(8.0,7.0,6.0,4.0,5.0,6.0,1.0,2.0,3.0));
@@ -310,8 +314,8 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     DataFrame dfLR = sqlContext.load("LRParquet/data/");
     HashMap<String, String> options = new HashMap<String, String>();
     options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, "TestLR");
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, "TestLR");
     options.put("preserveschema", "Y");
     dfLR.write().format("solr").options(options).mode(SaveMode.Overwrite).save();
     dfLR.show();
@@ -343,9 +347,9 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     DataFrame dfNB = sqlContext.load("NBParquet/data/");
     HashMap<String, String> options = new HashMap<String, String>();
     options = new HashMap<String, String>();
-    options.put(SolrRelation.SOLR_ZK_HOST_PARAM, zkHost);
+    options.put(SolrRDD.SOLR_ZK_HOST_PARAM, zkHost);
     options.put("preserveschema", "Y");
-    options.put(SolrRelation.SOLR_COLLECTION_PARAM, "TestNB");
+    options.put(SolrRDD.SOLR_COLLECTION_PARAM, "TestNB");
     dfNB.write().format("solr").options(options).mode(SaveMode.Overwrite).save();
     dfNB.show();
     Thread.sleep(5000);


### PR DESCRIPTION
@thelabdude The nested tests have been fixed in this refactor with more aggressive checks against the internal fieldList length in the getQuerySchema call and applyFields calls