### PR TITLE
Adding the support for a Streaming Iterator that uses Solr's Export H…

### DIFF
--- a/src/main/java/com/lucidworks/spark/query/SerializedTuple.java
+++ b/src/main/java/com/lucidworks/spark/query/SerializedTuple.java
@@ -1,0 +1,82 @@
+package com.lucidworks.spark.query;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.solr.client.solrj.io.Tuple;
+
+@SuppressWarnings({ "unchecked", "rawtypes" })
+public class SerializedTuple implements Serializable {
+
+	public SerializedTuple(Tuple tuple) {
+		fields = tuple.getMap();
+		this.EOF = tuple.EOF;
+	}
+
+	public SerializedTuple(HashMap m, boolean EOF) {
+		fields = m;
+		this.EOF = EOF;
+	}
+
+	private static final long serialVersionUID = 1L;
+
+	public boolean EOF;
+	public Map fields = new HashMap();
+
+	public Object get(Object key) {
+		return fields.get(key);
+	}
+
+	public void put(Object key, Object value) {
+		fields.put(key, value);
+	}
+
+	public String getString(Object key) {
+		return (String) fields.get(key);
+	}
+
+	public Long getLong(Object key) {
+		return (Long) fields.get(key);
+	}
+
+	public Double getDouble(Object key) {
+		return (Double) fields.get(key);
+	}
+
+	public List<String> getStrings(Object key) {
+		return (List<String>) fields.get(key);
+	}
+
+	public List<Long> getLongs(Object key) {
+		return (List<Long>) fields.get(key);
+	}
+
+	public List<Double> getDoubles(Object key) {
+		return (List<Double>) fields.get(key);
+	}
+
+	public Map getMap() {
+		return fields;
+	}
+
+	public List<Map> getMaps() {
+		return (List<Map>) fields.get("_MAPS_");
+	}
+
+	public void setMaps(List<Map> maps) {
+		fields.put("_MAPS_", maps);
+	}
+
+	public Map<String, Map> getMetrics() {
+		return (Map<String, Map>) fields.get("_METRICS_");
+	}
+
+	public void setMetrics(Map<String, Map> metrics) {
+		fields.put("_METRICS_", metrics);
+	}
+
+	public SerializedTuple clone() {
+		return new SerializedTuple(new HashMap(fields), EOF);
+	}
+}

--- a/src/main/java/com/lucidworks/spark/query/SolrStreamIterator.java
+++ b/src/main/java/com/lucidworks/spark/query/SolrStreamIterator.java
@@ -1,0 +1,131 @@
+package com.lucidworks.spark.query;
+
+import org.apache.commons.collections.IteratorUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.log4j.Logger;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.io.Tuple;
+import org.apache.solr.client.solrj.io.stream.SolrStream;
+import org.apache.solr.common.SolrDocument;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+/**
+ * An iterator over a stream of query results from one Solr Core. It is a
+ * wrapper over the SolrStream to adapt it to an iterator interface.
+ *
+ * This iterator is not thread safe. It is intended to be used within the
+ * context of a single thread.
+ */
+public class SolrStreamIterator implements Iterator<SolrDocument>, Iterable<SolrDocument> {
+
+    private static final Logger log = Logger.getLogger(SolrStreamIterator.class);
+
+    private SolrStream stream;
+    protected SolrClient solrServer;
+    protected SolrQuery solrQuery;
+    protected boolean closeAfterIterating;
+    private boolean isOpenStream;
+    private SolrDocument currentTuple = null;
+
+    public SolrStreamIterator(String shardUrl, SolrClient solrServer, SolrQuery solrQuery) {
+        this.solrServer = solrServer;
+        this.closeAfterIterating = !(solrServer instanceof CloudSolrClient);
+        this.solrQuery = solrQuery;
+
+        Map<String, Object> params = getAll(solrQuery, null,
+                (String[]) IteratorUtils.toArray(solrQuery.getParameterNamesIterator(), String.class));
+        this.stream = new SolrStream(shardUrl, params);
+        openStream();
+    }
+
+    /**Copy all params to the given map or if the given map is null
+     * create a new one
+     */
+    public Map<String, Object> getAll(SolrQuery solrQuery, Map<String, Object> sink, String... params){
+        if(sink == null) sink = new LinkedHashMap<>();
+        for (String param : params) {
+            String[] v = solrQuery.getParams(param);
+            if(v != null && v.length>0 ) {
+                if(v.length == 1) {
+                    sink.put(param, v[0]);
+                } else {
+                    sink.put(param,v);
+                }
+            }
+        }
+        return sink;
+    }
+
+    public synchronized boolean hasNext() {
+        try {
+            if (currentTuple == null) {
+                currentTuple = fetchNextDocument();
+            }
+        } catch (IOException e) {
+            log.error("Failed to fetch next document.", e);
+            throw new RuntimeException(e);
+        }
+
+        if (currentTuple == null && closeAfterIterating) {
+            // TODO: upstream change to SolrStream to make it AutoCloseable
+            try {
+                stream.close();
+            } catch (IOException e) {
+                log.error("Failed to close the SolrStream.", e);
+                throw new RuntimeException(e);
+            }
+            IOUtils.closeQuietly(solrServer);
+        }
+
+        return currentTuple != null;
+    }
+
+    protected SolrDocument fetchNextDocument() throws IOException {
+        Tuple tuple = stream.read();
+        if (tuple.EOF)
+            return null;
+
+        final SolrDocument doc = new SolrDocument();
+        for (Object key : tuple.fields.keySet()) {
+            doc.setField((String) key, tuple.get(key));
+        }
+
+        return doc;
+    }
+
+    private void openStream() {
+        try {
+            if (isOpenStream)
+                return;
+            stream.open();
+            // stream.setTrace(true);
+            isOpenStream = true;
+        } catch (IOException e1) {
+            throw new RuntimeException(e1);
+        }
+    }
+
+    public synchronized SolrDocument next() {
+        if (currentTuple == null)
+            throw new NoSuchElementException();
+
+        final SolrDocument tempCurrentTuple = currentTuple;
+        currentTuple = null;
+        return tempCurrentTuple;
+    }
+
+    public void remove() {
+        throw new UnsupportedOperationException("remove is not supported");
+    }
+
+    public Iterator<SolrDocument> iterator() {
+        return this;
+    }
+}

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -2,7 +2,7 @@ package com.lucidworks.spark.rdd
 
 import java.net.InetAddress
 
-import com.lucidworks.spark.query.StreamingResultsIterator
+import com.lucidworks.spark.query.{SolrStreamIterator, StreamingResultsIterator}
 import com.lucidworks.spark.util.{SolrQuerySupport, SolrSupport}
 import com.lucidworks.spark._
 import com.lucidworks.spark.util.QueryConstants._
@@ -19,27 +19,42 @@ import scala.util.Random
  * TODO: Add support for filter queries
  */
 class SolrRDD(
-    val zkHost: String,
-    val collection: String,
-    @transient sc: SparkContext,
-    query : Option[String] = Option(DEFAULT_QUERY),
-    fields: Option[Array[String]] = None,
-    rows: Option[Int] = Option(DEFAULT_PAGE_SIZE),
-    splitField: Option[String] = None,
-    splitsPerShard: Option[Int] = Option(DEFAULT_SPLITS_PER_SHARD),
-    solrQuery: Option[SolrQuery] = None)
+               val zkHost: String,
+               val collection: String,
+               @transient sc: SparkContext,
+               val useExportHandler: Boolean = false,
+               query : Option[String] = Option(DEFAULT_QUERY),
+               fields: Option[Array[String]] = None,
+               rows: Option[Int] = Option(DEFAULT_PAGE_SIZE),
+               splitField: Option[String] = None,
+               splitsPerShard: Option[Int] = Option(DEFAULT_SPLITS_PER_SHARD),
+               solrQuery: Option[SolrQuery] = None
+    )
   extends RDD[SolrDocument](sc, Seq.empty) with Logging{ //TODO: Do we need to pass any deps on parent RDDs for Solr?
 
   val uniqueKey = SolrQuerySupport.getUniqueKey(zkHost, collection)
 
   protected def copy(
+    useExportHandler: Boolean = false,
     query: Option[String] = query,
     fields: Option[Array[String]] = fields,
     rows: Option[Int] = rows,
     splitField: Option[String] = splitField,
     splitsPerShard: Option[Int] = splitsPerShard,
     solrQuery: Option[SolrQuery] = solrQuery): SolrRDD = {
-    new SolrRDD(zkHost, collection, sc, query, fields, rows, splitField, splitsPerShard, solrQuery)
+    new SolrRDD(zkHost, collection, sc, useExportHandler, query, fields, rows, splitField, splitsPerShard, solrQuery)
+  }
+
+
+  /*
+  * Get an Iterator that uses the export handler in Solr
+  */
+  @throws(classOf[Exception])
+  private def getExportHandlerBasedIterator(shardUrl : String, query : SolrQuery) = {
+
+    // Direct the queries to each shard, so we don't want distributed
+    query.set("distrib", false);
+    new SolrStreamIterator(shardUrl, SolrSupport.getHttpSolrClient(shardUrl), query)
   }
 
   @DeveloperApi
@@ -50,14 +65,19 @@ class SolrRDD(
 
         //TODO: Add backup mechanism to StreamingResultsIterator by being able to query any replica in case the main url goes down
         val url = partition.preferredReplica.replicaUrl
+        val query = partition.query
         log.info("Using the shard url " + url + " for getting partition data")
-        val streamingIterator = new StreamingResultsIterator(
-          SolrSupport.getHttpSolrClient(url),
-          partition.query,
-          partition.cursorMark)
+        val streamingIterator =
+          if (useExportHandler)
+            getExportHandlerBasedIterator(url, query)
+          else
+            new StreamingResultsIterator(
+              SolrSupport.getHttpSolrClient(url),
+              partition.query,
+              partition.cursorMark)
 
         context.addTaskCompletionListener { (context) =>
-          log.info(f"Fetched ${streamingIterator.getNumDocs} rows from shard $url for partition ${split.index}")
+          log.info(f"Fetched rows from shard $url for partition ${split.index}") // SolrStreamIterator needs to store
         }
         JavaConverters.asScalaIteratorConverter(streamingIterator.iterator()).asScala
 

--- a/src/test/scala/com/lucidworks/spark/RDDTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/RDDTestSuite.scala
@@ -3,6 +3,7 @@ package com.lucidworks.spark
 import java.util.UUID
 import com.lucidworks.spark.rdd.SolrRDD
 import com.lucidworks.spark.util.SolrCloudUtil
+
 import org.apache.spark.Logging
 
 class RDDTestSuite extends SparkSolrFunSuite with SparkSolrContextBuilder with Logging {
@@ -25,6 +26,33 @@ class RDDTestSuite extends SparkSolrFunSuite with SparkSolrContextBuilder with L
       val newRDD = new SolrRDD(zkHost, collectionName, sc)
       val partitions = newRDD.partitions
       assert(partitions.length === 4)
+    } finally {
+      SolrCloudUtil.deleteCollection(collectionName, cluster)
+    }
+  }
+
+  test("Test Simple Query that uses ExportHandler") {
+    val collectionName = "testSimpleQuery" + UUID.randomUUID().toString
+    SolrCloudUtil.buildCollection(zkHost, collectionName, 3999, 2, cloudClient, sc)
+    try {
+      val newRDD = new SolrRDD(zkHost, collectionName, sc,
+                      useExportHandler=true, rows=Option(Integer.MAX_VALUE))
+      val cnt = newRDD.count()
+      print("\n********************** RDD COUNT IS = " + cnt + "\n\n")
+      assert(cnt === 3999)
+    } finally {
+      SolrCloudUtil.deleteCollection(collectionName, cluster)
+    }
+  }
+
+  test("Test RDD Partitions with an RDD that uses query using ExportHandler") {
+    val collectionName = "testRDDPartitions" + UUID.randomUUID().toString
+    SolrCloudUtil.buildCollection(zkHost, collectionName, 1002, 14, cloudClient, sc)
+    try {
+      val newRDD = new SolrRDD(zkHost, collectionName, sc,
+                      useExportHandler=true,  rows=Option(Integer.MAX_VALUE))
+      val partitions = newRDD.partitions
+      assert(partitions.length === 14)
     } finally {
       SolrCloudUtil.deleteCollection(collectionName, cluster)
     }


### PR DESCRIPTION
Adding the support for a Streaming Iterator that uses Solr's Export Handler. This iterator is made available for use  in queries that are used in the compute() of  SolrRDD
