### PR TITLE
Introduce new config option as a fix for case sensitive arbitrary par…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -277,14 +277,14 @@ option("dv", "true")
 
 Since 5.5.0 Solr will return non-stored docValues by default. This option is only needed for versions that are older than 5.5
 
-=== solr.
+=== solr.params
 
-The "solr." prefix option is used for providing arbitrary Solr query parameters.
+The "solr.params" option is used for providing arbitrary Solr query parameters (just like a normal Solr query)
 
 [source]
-option("solr.defType", "edismax")
+option("solr.params", "defType=edismax&timeAllowed=0")
 
-The options provided with this prefix have precedence over other options 'fields', 'query', 'rows'
+The params provided here will override the common Solr params 'fields', 'query', 'rows'
 
 == Reading data from Solr as a Spark RDD
 

--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -8,8 +8,6 @@ class SolrConf(config: Map[String, String]) {
   require(config != null, "Config cannot be null")
   require(config.nonEmpty, "Config cannot be empty")
 
-  val solrConfigParams: ModifiableSolrParams = SolrConf.parseSolrParams(config)
-
   def getZkHost: Option[String] = {
     if (config.contains(SOLR_ZK_HOST_PARAM)) return config.get(SOLR_ZK_HOST_PARAM)
     None
@@ -109,22 +107,3 @@ class SolrConf(config: Map[String, String]) {
     solrParams
   }
 }
-
-object SolrConf {
-
-  // Anything in the form of "solr.*" will override the "q", "fields", "rows" in the config
-  def parseSolrParams(config: Map[String, String]): ModifiableSolrParams = {
-    val params = new ModifiableSolrParams()
-
-    for (key <- config.keySet) {
-      if (key.startsWith(CONFIG_PREFIX)) {
-        val param = key.substring(CONFIG_PREFIX.length)
-        if (config.get(key).isDefined) {
-          params.add(param, config.get(key).get)
-        }
-      }
-    }
-    params
-  }
-}
-

--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -92,6 +92,22 @@ class SolrConf(config: Map[String, String]) {
     }
     None
   }
+
+  def getArbitrarySolrParams: ModifiableSolrParams = {
+    val solrParams = new ModifiableSolrParams()
+    if (config.contains(ARBITRARY_PARAMS_STRING) && config.get(ARBITRARY_PARAMS_STRING).isDefined) {
+      val paramString = config.get(ARBITRARY_PARAMS_STRING).get
+      val params = paramString.split("&")
+
+      for (param <- params) {
+        val keyValue = param.split("=")
+        val key = keyValue(0)
+        val value = keyValue(1)
+        solrParams.add(key, value)
+      }
+    }
+    solrParams
+  }
 }
 
 object SolrConf {

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -41,7 +41,7 @@ class SolrRelation(
   checkRequiredParams()
   // Warn about unknown parameters
   val unknownParams = SolrRelation.checkUnknownParams(parameters.keySet)
-  if (!unknownParams.isEmpty)
+  if (unknownParams.nonEmpty)
     log.warn("Unknown parameters passed to query: " + unknownParams.toString())
 
   val sc = sqlContext.sparkContext
@@ -240,6 +240,7 @@ class SolrRelation(
 
     query.setRows(scala.Int.box(conf.getRows.getOrElse(DEFAULT_PAGE_SIZE)))
     query.add(conf.solrConfigParams)
+    query.add(conf.getArbitrarySolrParams)
     query.set("collection", conf.getCollection.get)
     query
   }

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -239,7 +239,6 @@ class SolrRelation(
     }
 
     query.setRows(scala.Int.box(conf.getRows.getOrElse(DEFAULT_PAGE_SIZE)))
-    query.add(conf.solrConfigParams)
     query.add(conf.getArbitrarySolrParams)
     query.set("collection", conf.getCollection.get)
     query
@@ -265,18 +264,13 @@ object SolrRelation {
     val instanceMirror = rm.reflect(ConfigurationConstants)
 
     for(acc <- accessors) {
-      if (acc.name.decoded != "CONFIG_PREFIX") {
-        knownParams += instanceMirror.reflectMethod(acc).apply().toString
-      }
+      knownParams += instanceMirror.reflectMethod(acc).apply().toString
     }
 
     // Check for any unknown options
     keySet.foreach(key => {
       if (!knownParams.contains(key)) {
-        // Now check if the prefix is "solr."
-        if (!key.contains(CONFIG_PREFIX)) {
-          unknownParams += key
-        }
+        unknownParams += key
       }
     })
     unknownParams

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -87,9 +87,9 @@ class SolrRDD(
     val query = if (solrQuery.isEmpty) buildQuery else solrQuery.get
     // Add defaults for shards. TODO: Move this for different implementations (Streaming)
     SolrQuerySupport.setQueryDefaultsForShards(query, uniqueKey)
-    var partitions = if (splitField.isDefined)
+    val partitions = if (splitField.isDefined)
       SolrPartitioner.getSplitPartitions(shards, query, splitField.get, splitsPerShard.get) else SolrPartitioner.getShardPartitions(shards, query)
-    log.info(s"Found ${partitions.length} partitions: ${partitions}")
+    log.info(s"Found ${partitions.length} partitions: ${partitions.mkString(",")}")
     partitions
   }
 

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -3,6 +3,7 @@ package com.lucidworks.spark.util
 // This should only be used for config options for the sql statements [SolrRelation]
 object ConfigurationConstants {
   val CONFIG_PREFIX: String = "solr."
+  val ARBITRARY_PARAMS_STRING: String = "query.params"
   val SOLR_ZK_HOST_PARAM: String = "zkhost"
   val SOLR_COLLECTION_PARAM: String = "collection"
   val SOLR_QUERY_PARAM: String = "query"

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -2,8 +2,7 @@ package com.lucidworks.spark.util
 
 // This should only be used for config options for the sql statements [SolrRelation]
 object ConfigurationConstants {
-  val CONFIG_PREFIX: String = "solr."
-  val ARBITRARY_PARAMS_STRING: String = "query.params"
+  val ARBITRARY_PARAMS_STRING: String = "solr.params"
   val SOLR_ZK_HOST_PARAM: String = "zkhost"
   val SOLR_COLLECTION_PARAM: String = "collection"
   val SOLR_QUERY_PARAM: String = "query"

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -70,26 +70,18 @@ class EventsimTestSuite extends EventsimBuilder {
     }
   }
 
-  test("Test arbitrary params using the prefix") {
-    val options = Map(
-      SOLR_ZK_HOST_PARAM -> zkHost,
-      SOLR_COLLECTION_PARAM -> collectionName,
-      CONFIG_PREFIX + "fl" -> "id,registration"
-    )
-    val df = sqlContext.read.format("solr").options(options).load()
-    val singleRow = df.take(1)(0)
-    assert(singleRow.length == 2)
-  }
-
   test("Test arbitrary params using the param string") {
     val options = Map(
       SOLR_ZK_HOST_PARAM -> zkHost,
       SOLR_COLLECTION_PARAM -> collectionName,
-      ARBITRARY_PARAMS_STRING -> "fl=id,registration"
+      ARBITRARY_PARAMS_STRING -> "fl=id,registration&fq=lastName:Powell&fq=artist:Interpol&defType=edismax&df=id"
     )
     val df = sqlContext.read.format("solr").options(options).load()
+    val count = df.count()
+    assert(count == 1)
     val singleRow = df.take(1)(0)
     assert(singleRow.length == 2)
+
   }
 
   def testCommons(solrRDD: SolrRDD): Unit = {

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -81,6 +81,17 @@ class EventsimTestSuite extends EventsimBuilder {
     assert(singleRow.length == 2)
   }
 
+  test("Test arbitrary params using the param string") {
+    val options = Map(
+      SOLR_ZK_HOST_PARAM -> zkHost,
+      SOLR_COLLECTION_PARAM -> collectionName,
+      ARBITRARY_PARAMS_STRING -> "fl=id,registration"
+    )
+    val df = sqlContext.read.format("solr").options(options).load()
+    val singleRow = df.take(1)(0)
+    assert(singleRow.length == 2)
+  }
+
   def testCommons(solrRDD: SolrRDD): Unit = {
     val sparkCount = solrRDD.count()
 

--- a/src/test/scala/com/lucidworks/spark/RelationTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/RelationTestSuite.scala
@@ -5,7 +5,7 @@ import com.lucidworks.spark.util.ConfigurationConstants._
 class RelationTestSuite extends SparkSolrFunSuite {
 
   test("Unknown params") {
-    val paramsToCheck = Set(SOLR_ZK_HOST_PARAM, SOLR_COLLECTION_PARAM, SOLR_QUERY_PARAM, ESCAPE_FIELDNAMES_PARAM, "fl", "q", "solr.defType")
+    val paramsToCheck = Set(SOLR_ZK_HOST_PARAM, SOLR_COLLECTION_PARAM, SOLR_QUERY_PARAM, ESCAPE_FIELDNAMES_PARAM, "fl", "q")
     val unknownParams = SolrRelation.checkUnknownParams(paramsToCheck)
     assert(unknownParams.size == 2)
     assert(unknownParams("q"))


### PR DESCRIPTION
…ams #41

* Currently, arbitrary params can be passed to SolrRelation through `solr.***` in the options. Example:
  
   ```scala    
   val options = Map(
        "zkHost" -> zkHosts,
        "collection" -> collection,
        "fields" -> fields,
        "solr.timeAllowed" -> "0"
      )
    ```
  However, Spark uses a CaseInsensitiveMap which turns all keys to be case sensitive. In this case, timeAllowed is lower cased to timeallowed
 before it is sent to Solr
* To overcome this, this issue introduces a new config option where we can specify query params as a the value (like a normal Solr query). Example:

       ```scala
       val options = Map(
        "zkHost" -> zkHosts,
        "collection" -> collection,
        "fields" -> fields,
        "solr.params" -> "timeAllowed=0"
      )
      ```
* This PR gets rid of the prefix based config `solr.`