### PR TITLE
 Support for timestamp filters from Spark SQL

### DIFF
--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -89,7 +89,8 @@ class SolrRDD(
       SolrQuerySupport.setQueryDefaultsForShards(query, uniqueKey)
     val partitions = if (splitField.isDefined)
       SolrPartitioner.getSplitPartitions(shards, query, splitField.get, splitsPerShard.get) else SolrPartitioner.getShardPartitions(shards, query)
-    log.info(s"Found ${partitions.length} partitions: ${partitions.mkString(",")}")
+    if (log.isDebugEnabled)
+      log.debug(s"Found ${partitions.length} partitions: ${partitions.mkString(",")}")
     partitions
   }
 

--- a/src/test/java/com/lucidworks/spark/SolrRelationTest.java
+++ b/src/test/java/com/lucidworks/spark/SolrRelationTest.java
@@ -1,7 +1,9 @@
 package com.lucidworks.spark;
 
 import com.lucidworks.spark.util.Constants;
+import com.lucidworks.spark.util.SolrSupport;
 import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.spark.sql.DataFrame;
 import org.apache.spark.sql.Row;
@@ -323,7 +325,10 @@ public class SolrRelationTest extends RDDProcessorTestBase {
     options.put(SOLR_ZK_HOST_PARAM(), zkHost);
     options.put(SOLR_COLLECTION_PARAM(), testCollection);
     sourceData.write().format(Constants.SOLR_FORMAT()).options(options).mode(SaveMode.Overwrite).save();
-    Thread.sleep(1000);
+
+    // Explicit commit to make sure all docs are visible
+    CloudSolrClient solrCloudClient = SolrSupport.getCachedCloudClient(zkHost);
+    solrCloudClient.commit(testCollection, true, true);
 
     SolrQuery q = new SolrQuery("*:*");
     q.setRows(100);

--- a/src/test/java/com/lucidworks/spark/SolrSqlTest.java
+++ b/src/test/java/com/lucidworks/spark/SolrSqlTest.java
@@ -59,7 +59,7 @@ public class SolrSqlTest extends RDDProcessorTestBase{
         // list of fields that are present in src/test/resources/eventsim/fields_schema.json
         assert fieldNames.length == 19 + 1 + 1; // extra fields are id and _version_
 
-        Assert.assertEquals(schema.apply("timestamp").dataType().typeName(), DataTypes.TimestampType.typeName());
+        Assert.assertEquals(schema.apply("ts").dataType().typeName(), DataTypes.TimestampType.typeName());
         Assert.assertEquals(schema.apply("sessionId").dataType().typeName(), DataTypes.IntegerType.typeName());
         Assert.assertEquals(schema.apply("length").dataType().typeName(), DataTypes.DoubleType.typeName());
         Assert.assertEquals(schema.apply("song").dataType().typeName(), DataTypes.StringType.typeName());
@@ -72,7 +72,7 @@ public class SolrSqlTest extends RDDProcessorTestBase{
         DataFrame eventsim = sqlContext.read().format("solr").options(options).load();
         eventsim.registerTempTable("eventsim");
 
-        DataFrame records = sqlContext.sql("SELECT `userId`, `timestamp` from eventsim WHERE `gender` = 'M'");
+        DataFrame records = sqlContext.sql("SELECT `userId`, `ts` from eventsim WHERE `gender` = 'M'");
         assert records.count() == 567;
       }
 

--- a/src/test/java/com/lucidworks/spark/util/EventsimUtil.java
+++ b/src/test/java/com/lucidworks/spark/util/EventsimUtil.java
@@ -82,7 +82,6 @@ public class EventsimUtil {
     log.info("Indexing eventsim documents from file " + datasetPath);
 
     df.registerTempTable("jdbcDF");
-
     sqlContext.udf().register("ts2ISO", new UDF1<Long, Timestamp>() {
       public Timestamp call(Long ts) {
         return asDate(ts);
@@ -91,8 +90,8 @@ public class EventsimUtil {
 
     // Registering an UDF and re-using it via DataFrames is not available through Java right now.
     DataFrame newDF = sqlContext.sql("SELECT userAgent, userId, artist, auth, firstName, gender, itemInSession, lastName, " +
-      "length, level, location, method, page, ts2ISO(registration) AS registration, sessionId, song, status, " +
-      "ts2ISO(ts) AS timestamp from jdbcDF");
+      "length, level, location, method, page, sessionId, song,  " +
+      "ts2ISO(registration) AS registration, ts2ISO(ts) AS timestamp1, status from jdbcDF");
 
     HashMap<String, String> options = new HashMap<String, String>();
     options.put("zkhost", zkHost);

--- a/src/test/java/com/lucidworks/spark/util/EventsimUtil.java
+++ b/src/test/java/com/lucidworks/spark/util/EventsimUtil.java
@@ -91,7 +91,7 @@ public class EventsimUtil {
     // Registering an UDF and re-using it via DataFrames is not available through Java right now.
     DataFrame newDF = sqlContext.sql("SELECT userAgent, userId, artist, auth, firstName, gender, itemInSession, lastName, " +
       "length, level, location, method, page, sessionId, song,  " +
-      "ts2ISO(registration) AS registration, ts2ISO(ts) AS timestamp1, status from jdbcDF");
+      "ts2ISO(registration) AS registration, ts2ISO(ts) AS ts, status from jdbcDF");
 
     HashMap<String, String> options = new HashMap<String, String>();
     options.put("zkhost", zkHost);

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -118,6 +118,17 @@ class EventsimTestSuite extends EventsimBuilder {
     assert(queryDF.count() == eventSimCount)
   }
 
+  test("Timestamp filter queries") {
+    val df: DataFrame = sqlContext.read.format("solr")
+      .option("zkHost", zkHost)
+      .option("collection", collectionName)
+      .load()
+    df.registerTempTable("events")
+
+    val timeQueryDF = sqlContext.sql("SELECT * from events WHERE `registration` = '2015-05-31 11:03:07Z'")
+    assert(timeQueryDF.count() == 11)
+  }
+
   def testCommons(solrRDD: SolrRDD): Unit = {
     val sparkCount = solrRDD.count()
 

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -129,6 +129,29 @@ class EventsimTestSuite extends EventsimBuilder {
     assert(timeQueryDF.count() == 11)
   }
 
+  test("Length range filter queries") {
+    val df: DataFrame = sqlContext.read.format("solr")
+      .option("zkHost", zkHost)
+      .option("collection", collectionName)
+      .load()
+    df.registerTempTable("events")
+
+    val timeQueryDF = sqlContext.sql("SELECT * from events WHERE `length` >= '700' and `length` <= '1000'")
+    assert(timeQueryDF.count() == 1)
+  }
+
+  // Ignored since Spark is not passing timestamps filters to the buildScan method. Range timestamp filtering is being done at Spark layer
+  ignore("Timestamp range filter queries") {
+    val df: DataFrame = sqlContext.read.format("solr")
+      .option("zkHost", zkHost)
+      .option("collection", collectionName)
+      .load()
+    df.registerTempTable("events")
+
+    val timeQueryDF = sqlContext.sql("SELECT * from events WHERE `registration` >= '2015-05-28' AND `registration` <= '2015-05-29' ")
+    assert(timeQueryDF.count() == 21)
+  }
+
   def testCommons(solrRDD: SolrRDD): Unit = {
     val sparkCount = solrRDD.count()
 
@@ -136,6 +159,5 @@ class EventsimTestSuite extends EventsimBuilder {
     assert(sparkCount == solrRDD.solrCount.toLong)
     assert(sparkCount == eventSimCount)
   }
-
 
 }


### PR DESCRIPTION
Fixes #40 which is to able to filter SQL queries using timestamp fields.

