### PR TITLE
Use export handler for querying by default (if possible)

### DIFF
--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -98,6 +98,13 @@ class SolrConf(config: Map[String, String]) {
     None
   }
 
+  def useCursorMarks: Option[Boolean] = {
+    if (config.contains(USE_CURSOR_MARKS) && config.get(USE_CURSOR_MARKS).isDefined) {
+      return Some(config.get(USE_CURSOR_MARKS).get.toBoolean)
+    }
+    None
+  }
+
   def genUniqKey: Option[Boolean] = {
     if (config.contains(GENERATE_UNIQUE_KEY) && config.get(GENERATE_UNIQUE_KEY).isDefined) {
       return Some(config.get(GENERATE_UNIQUE_KEY).get.toBoolean)

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -148,7 +148,7 @@ class SolrRelation(
       val querySchema = if (!fields.isEmpty) SolrRelationUtil.deriveQuerySchema(fields, baseSchema) else schema
       if (!solrRDD.exportHandler.getOrElse(false) && !conf.useCursorMarks.getOrElse(false)) {
         // Determine whether to use Streaming API (/export handler) when 'use_export_handler' option is not set
-        val useStreamingAPI: Boolean = SolrRelation.isStreamingPossible(querySchema, baseSchema, query, solrRDD.uniqueKey)
+        val useStreamingAPI: Boolean = SolrRelation.isStreamingPossible(querySchema, baseSchema, query)
         val docs = solrRDD.useExportHandler(useStreamingAPI).query(query)
         val rows = SolrRelationUtil.toRows(querySchema, docs)
         rows
@@ -336,7 +336,7 @@ object SolrRelation extends Logging {
     unknownParams
   }
 
-  def isStreamingPossible(querySchema: StructType, baseSchema: StructType, query: SolrQuery, uniqueKey: String): Boolean = {
+  def isStreamingPossible(querySchema: StructType, baseSchema: StructType, query: SolrQuery): Boolean = {
     // Check if all the fields in the querySchema have docValues enabled
     for (structField <- querySchema.fields) {
       val metadata = structField.metadata

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -2,7 +2,6 @@ package com.lucidworks.spark
 
 import java.util.UUID
 
-import com.lucidworks.spark.SolrRelation._
 import com.lucidworks.spark.util._
 import com.lucidworks.spark.rdd.SolrRDD
 import org.apache.http.entity.StringEntity
@@ -289,10 +288,9 @@ class SolrRelation(
         return false
     }
 
+    val sortClauses = query.getSorts.asScala.toList
 
-    val sortClauses = query.getSorts
-
-    if (!sortClauses.isEmpty) {
+    if (sortClauses.nonEmpty) {
       // Check if the sorted field (if exists) has docValue enabled
       for (sortClause: SortClause <- sortClauses) {
         val sortField = sortClause.getItem

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -19,7 +19,7 @@ class SolrRDD(
     val zkHost: String,
     val collection: String,
     @transient sc: SparkContext,
-    exportHandler: Option[Boolean] = None,
+    val exportHandler: Option[Boolean] = None,
     query : Option[String] = Option(DEFAULT_QUERY),
     fields: Option[Array[String]] = None,
     rows: Option[Int] = Option(DEFAULT_PAGE_SIZE),

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -62,16 +62,19 @@ class SolrRDD(
         //TODO: Add backup mechanism to StreamingResultsIterator by being able to query any replica in case the main url goes down
         val url = partition.preferredReplica.replicaUrl
         val query = partition.query
-        log.info("Using the shard url " + url + " for getting partition data for split: "+split)
+        log.info("Using the shard url " + url + " for getting partition data for split: "+ split.index)
         val resultsIterator: ResultsIterator =
-          if (exportHandler.isDefined && exportHandler.get)
+          if (exportHandler.isDefined && exportHandler.get) {
+            log.info("Using export handler to fetch documents from Solr")
             getExportHandlerBasedIterator(url, query)
-          else
+          }
+          else {
+            log.info("Using cursorMarks to fetch documents from Solr")
             new StreamingResultsIterator(
               SolrSupport.getHttpSolrClient(url),
               partition.query,
               partition.cursorMark)
-
+          }
         context.addTaskCompletionListener { (context) =>
           log.info(f"Fetched ${resultsIterator.getNumDocs} rows from shard $url for partition ${split.index}")
         }
@@ -85,7 +88,7 @@ class SolrRDD(
     val shards = SolrSupport.buildShardList(zkHost, collection)
     val query = if (solrQuery.isEmpty) buildQuery else solrQuery.get
     // Add defaults for shards. TODO: Move this for different implementations (Streaming)
-    if (!(exportHandler.isDefined && exportHandler.get))
+    if (!exportHandler.getOrElse(false))
       SolrQuerySupport.setQueryDefaultsForShards(query, uniqueKey)
     val partitions = if (splitField.isDefined)
       SolrPartitioner.getSplitPartitions(shards, query, splitField.get, splitsPerShard.get) else SolrPartitioner.getShardPartitions(shards, query)

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -130,6 +130,8 @@ class SolrRDD(
 
   def useExportHandler: SolrRDD = copy(exportHandler = Some(true))
 
+  def useExportHandler(exportHandler: Boolean): SolrRDD = copy(exportHandler = Some(exportHandler))
+
   def solrCount: BigInt = SolrQuerySupport.getNumDocsFromSolr(collection, zkHost, solrQuery)
 
   def buildQuery: SolrQuery = {

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -16,6 +16,7 @@ object ConfigurationConstants {
   val SOLR_DOC_VALUES: String = "dv"
   val FLATTEN_MULTIVALUED: String = "flatten_multivalued"
   val USE_EXPORT_HANDLER: String = "use_export_handler"
+  val USE_CURSOR_MARKS: String = "use_cursor_marks"
 
   // Index params
   val SOFT_AUTO_COMMIT_SECS: String = "soft_commit_secs"

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -170,8 +170,21 @@ class EventsimTestSuite extends EventsimBuilder {
     val df: DataFrame = sqlContext.read.format("solr")
     .option("zkHost", zkHost)
     .option("collection", collectionName)
-    .option(ARBITRARY_PARAMS_STRING, "fl=status,length&sort=id desc") // The test will fail without the fl param here
+    .option(ARBITRARY_PARAMS_STRING, "fl=status,length&sort=id desc")
     .load()
+    df.registerTempTable("events")
+
+    val queryDF = sqlContext.sql("SELECT count(distinct status), avg(length) FROM events")
+    val values = queryDF.collect()
+    assert(values(0)(0) == 3)
+  }
+
+  test("Non streaming query with cursor marks option") {
+    val df: DataFrame = sqlContext.read.format("solr")
+      .option("zkHost", zkHost)
+      .option("collection", collectionName)
+      .option(USE_CURSOR_MARKS, "true")
+      .load()
     df.registerTempTable("events")
 
     val queryDF = sqlContext.sql("SELECT count(distinct status), avg(length) FROM events")


### PR DESCRIPTION
* Automatically use export handler if the query fields and sort field have docValues enabled

