### PR TITLE
Random sample support

### DIFF
--- a/src/main/java/com/lucidworks/spark/query/StreamingResultsIterator.java
+++ b/src/main/java/com/lucidworks/spark/query/StreamingResultsIterator.java
@@ -7,6 +7,7 @@ import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 import org.apache.solr.client.solrj.StreamingResponseCallback;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
+import org.apache.solr.client.solrj.impl.HttpSolrClient;
 import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import scala.Option;
@@ -35,6 +36,8 @@ public class StreamingResultsIterator extends ResultsIterator {
   protected String cursorMarkOfCurrentPage = null;
   protected boolean closeAfterIterating = false;
   protected LinkedBlockingDeque<SolrDocument> queue;
+  protected Integer maxSampleDocs = null;
+  protected String solrId = null;
 
   private ResponseCallback responseCallback = new ResponseCallback();
   private CountDownLatch docListInfoLatch = new CountDownLatch(1);
@@ -46,6 +49,15 @@ public class StreamingResultsIterator extends ResultsIterator {
   public StreamingResultsIterator(SolrClient solrServer, SolrQuery solrQuery, String cursorMark) {
     this.queue = new LinkedBlockingDeque<SolrDocument>();
     this.solrServer = solrServer;
+
+    // get some identifier for this solr server
+    if (solrServer instanceof HttpSolrClient) {
+      HttpSolrClient httpSolrClient = (HttpSolrClient)solrServer;
+      solrId = httpSolrClient.getBaseURL();
+    } else {
+      solrId = solrServer.toString();
+    }
+
     this.closeAfterIterating = !(solrServer instanceof CloudSolrClient);
     this.solrQuery = solrQuery;
     this.usingCursors = (cursorMark != null);
@@ -56,7 +68,7 @@ public class StreamingResultsIterator extends ResultsIterator {
   }
 
   public boolean hasNext() {
-    if (totalDocs == 0 || (totalDocs != -1 && numDocs >= totalDocs))
+    if (totalDocs == 0 || (totalDocs != -1 && numDocs >= totalDocs) || (maxSampleDocs != null && maxSampleDocs >= 0 && numDocs >= maxSampleDocs))
       return false; // done iterating!
 
     boolean hasNext = false;
@@ -113,14 +125,14 @@ public class StreamingResultsIterator extends ResultsIterator {
         return totalDocs > 0;
       }
     } else {
-      throw new SolrServerException("No response found for query '" + solrQuery + "'");
+      throw new SolrServerException("No response from "+solrId+" found for query '" + solrQuery + "'");
     }
 
   }
 
   public SolrDocument next() {
     if (iterPos >= currentPageSize)
-      throw new NoSuchElementException("No more docs available! Please call hasNext before calling next!");
+      throw new NoSuchElementException("No more docs available from "+solrId+"! Please call hasNext before calling next!");
 
     SolrDocument next = null;
     try {
@@ -133,7 +145,7 @@ public class StreamingResultsIterator extends ResultsIterator {
     if (next == null) {
       throw new RuntimeException("No SolrDocument in queue (waited 60 seconds) while processing cursorMark="+
               cursorMarkOfCurrentPage+", read "+numDocs+" of "+totalDocs+
-          " so far. Most likely this means your query's sort criteria is not generating stable results for computing deep-paging cursors, has the index changed? " +
+          " so far from "+solrId+". Most likely this means your query's sort criteria is not generating stable results for computing deep-paging cursors, has the index changed? " +
           "If so, try using a filter criteria the bounds the results to non-changing data.");
     }
 
@@ -161,7 +173,7 @@ public class StreamingResultsIterator extends ResultsIterator {
       if (doc != null) {
         queue.offer(doc);
       } else {
-        log.warn("Received null SolrDocument from streamSolrDocument callback while processing cursorMark="+
+        log.warn("Received null SolrDocument from "+solrId+" callback while processing cursorMark="+
           cursorMarkOfCurrentPage+", read "+numDocs+" of "+totalDocs+" so far.");
       }
     }
@@ -169,6 +181,23 @@ public class StreamingResultsIterator extends ResultsIterator {
     public void streamDocListInfo(long numFound, long start, Float maxScore) {
       docListInfoLatch.countDown();
       totalDocs = numFound;
+
+      // see if they enabled sampling
+      if (maxSampleDocs == null) {
+        if (numFound > 0) {
+          String samplePctParam = solrQuery.get("sample_pct");
+          if (samplePctParam != null) {
+            float pct = Float.parseFloat(samplePctParam);
+            maxSampleDocs = Math.round((float)numFound * pct);
+            log.info("Sampling "+maxSampleDocs+" ("+pct+" of "+numFound+") from "+solrId);
+          } else {
+            maxSampleDocs = -1; // no sampling
+          }
+        } else {
+          maxSampleDocs = -1;
+        }
+      }
+
       if (currentPageSize > totalDocs)
         currentPageSize = (int)totalDocs;
     }

--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -105,6 +105,20 @@ class SolrConf(config: Map[String, String]) {
     None
   }
 
+  def sampleSeed: Option[Int] = {
+    if (config.contains(SAMPLE_SEED) && config.get(SAMPLE_SEED).isDefined) {
+      return Some(config.get(SAMPLE_SEED).get.toInt)
+    }
+    None
+  }
+
+  def samplePct: Option[Float] = {
+    if (config.contains(SAMPLE_PCT) && config.get(SAMPLE_PCT).isDefined) {
+      return Some(config.get(SAMPLE_PCT).get.toFloat)
+    }
+    None
+  }
+
   def getArbitrarySolrParams: ModifiableSolrParams = {
     val solrParams = new ModifiableSolrParams()
     if (config.contains(ARBITRARY_PARAMS_STRING) && config.get(ARBITRARY_PARAMS_STRING).isDefined) {

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -22,5 +22,8 @@ object ConfigurationConstants {
   val BATCH_SIZE: String = "batch_size"
   val GENERATE_UNIQUE_KEY: String = "gen_uniq_key"
 
+  val SAMPLE_SEED: String = "sample_seed"
+  val SAMPLE_PCT: String = "sample_pct"
+
   val ARBITRARY_PARAMS_STRING: String = "solr.params"
 }

--- a/src/test/resources/conf/managed-schema
+++ b/src/test/resources/conf/managed-schema
@@ -17,6 +17,7 @@
   <dynamicField indexed="true" name="*_ii" stored="true" type="int" multiValued="true"/>
   <dynamicField indexed="true" name="*_txt" stored="true" type="string" multiValued="true"/>
   <dynamicField indexed="true" name="*_ls" stored="true" type="long" multiValued="true"/>
+  <dynamicField name="random_*" type="random"/>
   <uniqueKey>id</uniqueKey>
   <fieldType name="string" class="solr.StrField" sortMissingLast="true"/>
   <fieldType name="long" class="solr.TrieLongField" precisionStep="6"/>
@@ -30,4 +31,5 @@
   <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true"/>
   <fieldType name="tdate" class="solr.TrieDateField" precisionStep="6" positionIncrementGap="0"/>
   <fieldType name="binary" class="solr.BinaryField"/>
+  <fieldType name="random" class="solr.RandomSortField" indexed="true"/>
 </schema>


### PR DESCRIPTION
allow users to read a random sample from all shards instead of the full dataset