### PR TITLE
Spar 29: Adding support for querying multiple collections

### DIFF
--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -49,6 +49,7 @@ class SolrRelation(
     log.warn("Unknown parameters passed to query: " + unknownParams.toString())
 
   val sc = sqlContext.sparkContext
+
   val solrRDD = {
     var rdd = new SolrRDD(
       conf.getZkHost.get,
@@ -83,7 +84,7 @@ class SolrRelation(
     SolrRelationUtil.getBaseSchema(
       solrFields.toSet,
       conf.getZkHost.get,
-      conf.getCollection.get,
+      conf.getCollection.get.split(",")(0),
       conf.escapeFieldNames.getOrElse(false),
       conf.flattenMultivalued.getOrElse(true))
 

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -29,7 +29,7 @@ class SolrRDD(
   extends RDD[SolrDocument](sc, Seq.empty)
   with Logging {
 
-  val uniqueKey = SolrQuerySupport.getUniqueKey(zkHost, collection)
+  val uniqueKey = SolrQuerySupport.getUniqueKey(zkHost, collection.split(",")(0))
 
   protected def copy(
       exportHandler: Option[Boolean] = exportHandler,

--- a/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
@@ -449,19 +449,19 @@ object SolrSupport extends Logging {
     val zkStateReader: ZkStateReader = solrClient.getZkStateReader
     val clusterState: ClusterState = zkStateReader.getClusterState
     var collections = Array.empty[String]
-  for(col <- collection.split(",")) {
-    if (clusterState.hasCollection(col)) {
-      collections = collections :+ col
+    for(col <- collection.split(",")) {
+      if (clusterState.hasCollection(col)) {
+        collections = collections :+ col
     }
     else {
       val aliases: Aliases = zkStateReader.getAliases
       val aliasedCollections: String = aliases.getCollectionAlias(col)
         if (aliasedCollections == null) {
           throw new IllegalArgumentException("Collection " + col + " not found!")
+        }
+      collections = aliasedCollections.split(",")
+      }
     }
-    collections = aliasedCollections.split(",")
-    }
-  }
     val liveNodes  = clusterState.getLiveNodes
 
     val shards = new ListBuffer[SolrShard]()

--- a/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
@@ -449,19 +449,20 @@ object SolrSupport extends Logging {
     val zkStateReader: ZkStateReader = solrClient.getZkStateReader
     val clusterState: ClusterState = zkStateReader.getClusterState
     var collections = Array.empty[String]
-
-    if (clusterState.hasCollection(collection)) {
-      collections = Array(collection)
+for(col <- collection.split(",")) {
+  if (clusterState.hasCollection(col)) {
+    collections = collections :+ col
+  }
+  else {
+    val aliases: Aliases = zkStateReader.getAliases
+    val aliasedCollections: String = aliases.getCollectionAlias(col)
+    if (aliasedCollections == null) {
+      throw new IllegalArgumentException("Collection " + col + " not found!")
     }
-    else {
-      val aliases: Aliases = zkStateReader.getAliases
-      val aliasedCollections: String = aliases.getCollectionAlias(collection)
-      if (aliasedCollections == null) {
-        throw new IllegalArgumentException("Collection " + collection + " not found!")
-      }
-      collections = aliasedCollections.split(",")
-    }
+    collections = aliasedCollections.split(",")
+  }
 
+}
     val liveNodes  = clusterState.getLiveNodes
 
     val shards = new ListBuffer[SolrShard]()

--- a/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
@@ -449,20 +449,19 @@ object SolrSupport extends Logging {
     val zkStateReader: ZkStateReader = solrClient.getZkStateReader
     val clusterState: ClusterState = zkStateReader.getClusterState
     var collections = Array.empty[String]
-for(col <- collection.split(",")) {
-  if (clusterState.hasCollection(col)) {
-    collections = collections :+ col
-  }
-  else {
-    val aliases: Aliases = zkStateReader.getAliases
-    val aliasedCollections: String = aliases.getCollectionAlias(col)
-    if (aliasedCollections == null) {
-      throw new IllegalArgumentException("Collection " + col + " not found!")
+  for(col <- collection.split(",")) {
+    if (clusterState.hasCollection(col)) {
+      collections = collections :+ col
+    }
+    else {
+      val aliases: Aliases = zkStateReader.getAliases
+      val aliasedCollections: String = aliases.getCollectionAlias(col)
+        if (aliasedCollections == null) {
+          throw new IllegalArgumentException("Collection " + col + " not found!")
     }
     collections = aliasedCollections.split(",")
+    }
   }
-
-}
     val liveNodes  = clusterState.getLiveNodes
 
     val shards = new ListBuffer[SolrShard]()

--- a/src/main/scala/solr/DefaultSource.scala
+++ b/src/main/scala/solr/DefaultSource.scala
@@ -9,7 +9,7 @@ class DefaultSource extends RelationProvider with CreatableRelationProvider with
 
   override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation = {
     try {
-      new SolrRelation(parameters, sqlContext)
+      return new SolrRelation(parameters, sqlContext)
     } catch {
       case re: RuntimeException => throw re
       case e: Exception => throw new RuntimeException(e)


### PR DESCRIPTION
The test has been added to TestQuerying.scala. The collections that we are querying to must have the same schema