### PR TITLE
use ${scala.binary.version} in jackson dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -488,17 +488,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.3.1</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.3.1</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.module</groupId>
-      <artifactId>jackson-module-scala_2.10</artifactId>
-      <version>2.3.1</version>
+      <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
Otherwise using scala 2.11 leads to "interesting" failures at runtime.