### PR TITLE
Prevent divide by zero

### DIFF
--- a/src/main/java/com/lucidworks/spark/query/AbstractFieldShardSplitStrategy.java
+++ b/src/main/java/com/lucidworks/spark/query/AbstractFieldShardSplitStrategy.java
@@ -228,7 +228,7 @@ public abstract class AbstractFieldShardSplitStrategy<T> implements ShardSplitSt
 
     long _startMs = System.currentTimeMillis();
 
-    int numSplits = Math.round(toBeSplit.getNumHits() / docsPerSplit);
+    int numSplits = docsPerSplit > 0 ? Math.round(toBeSplit.getNumHits() / docsPerSplit) : 1;
     if (numSplits == 1 && toBeSplit.getNumHits() > docsPerSplit)
       numSplits = 2;
 


### PR DESCRIPTION
This happens when the number of hits is less than the number of splits per shard.