### PR TITLE
Use HashQParser for computing splits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <spark.version>1.6.2</spark.version>
+    <spark.version>1.6.3</spark.version>
     <solr.version>6.1.0</solr.version>
     <fasterxml.version>2.4.0</fasterxml.version>
     <scala.version>2.10.5</scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.lucidworks.spark</groupId>
   <artifactId>spark-solr</artifactId>
-  <version>2.2.3</version>
+  <version>2.2.4-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>spark-solr</name>
   <description>Tools for reading data from Spark into Solr</description>

--- a/pom.xml
+++ b/pom.xml
@@ -256,6 +256,7 @@
                   <exclude>org.apache.spark:spark-core_${scala.binary.version}</exclude>
                   <exclude>org.apache.spark:spark-streaming_${scala.binary.version}</exclude>
                   <exclude>org.apache.spark:spark-hive_${scala.binary.version}</exclude>
+                  <exclude>org.apache.derby:*</exclude>
                   <exclude>org.apache.hadoop:*</exclude>
                   <exclude>com.google.protobuf_spark:*</exclude>
                   <exclude>com.twitter:chill_${scala.binary.version}</exclude>

--- a/src/main/java/com/lucidworks/spark/query/HashQParserShardSplitStrategy.java
+++ b/src/main/java/com/lucidworks/spark/query/HashQParserShardSplitStrategy.java
@@ -2,7 +2,6 @@ package com.lucidworks.spark.query;
 
 import com.lucidworks.spark.SolrReplica;
 import com.lucidworks.spark.SolrShard;
-import com.lucidworks.spark.rdd.SolrRDD;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.SolrServerException;
 

--- a/src/main/java/com/lucidworks/spark/query/HashQParserShardSplitStrategy.java
+++ b/src/main/java/com/lucidworks/spark/query/HashQParserShardSplitStrategy.java
@@ -1,5 +1,6 @@
 package com.lucidworks.spark.query;
 
+import com.lucidworks.spark.SolrReplica;
 import com.lucidworks.spark.SolrShard;
 import com.lucidworks.spark.rdd.SolrRDD;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -22,10 +23,15 @@ public class HashQParserShardSplitStrategy implements ShardSplitStrategy, Serial
   public List<ShardSplit> getSplits(String shardUrl, SolrQuery query, String splitFieldName, int numSplits) throws IOException, SolrServerException {
     query.set("partitionKeys", splitFieldName);
     List<ShardSplit> splits = new ArrayList<>(numSplits);
+    scala.collection.immutable.List<SolrReplica> replicas = shard.replicas();
+    final int numReplicas = replicas.size();
     for (int i=0; i < numSplits; i++) {
       String fq = "{!hash workers="+numSplits+" worker="+i+"}";
       // with hash, we can hit all replicas in the shard in parallel
-      String splitShardUrl = (shard != null) ? SolrRDD.randomReplicaLocation(shard) : shardUrl;
+      String splitShardUrl = shardUrl;
+      if (numReplicas > 1) {
+        splitShardUrl = (i < numReplicas) ? replicas.apply(i).replicaUrl() : replicas.apply(i % numReplicas).replicaUrl();
+      }
       splits.add(new WorkerShardSplit(query, splitShardUrl, splitFieldName, fq));
     }
     return splits;

--- a/src/main/java/com/lucidworks/spark/query/HashQParserShardSplitStrategy.java
+++ b/src/main/java/com/lucidworks/spark/query/HashQParserShardSplitStrategy.java
@@ -1,0 +1,49 @@
+package com.lucidworks.spark.query;
+
+import com.lucidworks.spark.SolrShard;
+import com.lucidworks.spark.rdd.SolrRDD;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.SolrServerException;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+public class HashQParserShardSplitStrategy implements ShardSplitStrategy, Serializable {
+
+  protected SolrShard shard;
+
+  public HashQParserShardSplitStrategy(SolrShard shard) {
+    this.shard = shard;
+  }
+
+  @Override
+  public List<ShardSplit> getSplits(String shardUrl, SolrQuery query, String splitFieldName, int numSplits) throws IOException, SolrServerException {
+    query.set("partitionKeys", splitFieldName);
+    List<ShardSplit> splits = new ArrayList<>(numSplits);
+    for (int i=0; i < numSplits; i++) {
+      String fq = "{!hash workers="+numSplits+" worker="+i+"}";
+      // with hash, we can hit all replicas in the shard in parallel
+      String splitShardUrl = (shard != null) ? SolrRDD.randomReplicaLocation(shard) : shardUrl;
+      splits.add(new WorkerShardSplit(query, splitShardUrl, splitFieldName, fq));
+    }
+    return splits;
+  }
+
+  class WorkerShardSplit extends AbstractShardSplit<String> {
+    WorkerShardSplit(SolrQuery query, String shardUrl, String rangeField, String fq) {
+      super(query, shardUrl, rangeField, fq);
+    }
+
+    @Override
+    public String nextUpper(String lower, long increment) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getRange() {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/src/main/java/com/lucidworks/spark/rdd/SolrJavaRDD.java
+++ b/src/main/java/com/lucidworks/spark/rdd/SolrJavaRDD.java
@@ -36,6 +36,10 @@ public class SolrJavaRDD extends JavaRDD<SolrDocument> {
     return wrap(rdd().query(solrQuery).splitField(splitFieldName).splitsPerShard(splitsPerShard));
   }
 
+  public JavaRDD<SolrDocument> queryNoSplits(String query) {
+    return wrap(rdd().query(query).splitsPerShard(1));
+  }
+
   @Override
   public SolrRDD rdd() {
     return solrRDD;

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -336,7 +336,7 @@ class SolrRelation(
       }
 
       if (rq.isEmpty && !conf.useCursorMarks.getOrElse(false)) {
-        logInfo(s"Checking the query and sort fields to determine if streaming is possible for ${collection}")
+        logDebug(s"Checking the query and sort fields to determine if streaming is possible for ${collection}")
         // Determine whether to use Streaming API (/export handler) if 'use_export_handler' or 'use_cursor_marks' options are not set
         val hasUnsupportedExportTypes : Boolean = SolrRelation.checkQueryFieldsForUnsupportedExportTypes(querySchema)
         val isFDV: Boolean = SolrRelation.checkQueryFieldsForDV(querySchema)
@@ -363,7 +363,7 @@ class SolrRelation(
           }
         }
 
-        logInfo(s"Existing sort clauses: ${sortClauses.mkString}")
+        logDebug(s"Existing sort clauses: ${sortClauses.mkString}")
         val isSDV: Boolean =
           if (sortClauses.nonEmpty)
             SolrRelation.checkSortFieldsForDV(collectionBaseSchema, sortClauses.toList)

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -619,8 +619,16 @@ object SolrRelation extends Logging {
   }
 
   def addSortField(querySchema: StructType, query: SolrQuery): Unit = {
-    query.addSort(querySchema.fields(0).name, SolrQuery.ORDER.asc)
-    log.info("Added sort field '" + query.getSortField + "' to the query")
+    querySchema.fields.foreach(field => {
+      if (field.metadata.contains("multiValued")) {
+        if (!field.metadata.getBoolean("multiValued")) {
+          query.addSort(field.name, SolrQuery.ORDER.asc)
+          return
+        }
+      }
+      query.addSort(field.name, SolrQuery.ORDER.asc)
+      return
+    })
   }
 
   // TODO: remove this check when https://issues.apache.org/jira/browse/SOLR-9187 is fixed

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -82,16 +82,29 @@ class SolrRelation(
       sqlContext.sparkContext,
       requestHandler = conf.requestHandler)
 
-    if (conf.splits.isDefined && conf.getSplitsPerShard.isDefined) {
-      rdd = rdd.doSplits().splitsPerShard(conf.getSplitsPerShard.get)
-    } else if (conf.splits.isDefined) {
-      rdd = rdd.doSplits()
+    if (conf.getSplitsPerShard.isDefined) {
+      // always apply this whether we're doing splits or not so that the user
+      // can pass splits_per_shard=1 to disable splitting when there are multiple replicas
+      // as we now will do splitting using the HashQParser when there are multiple active replicas
+      rdd = rdd.splitsPerShard(conf.getSplitsPerShard.get)
     }
 
-    if (conf.getSplitField.isDefined && conf.getSplitsPerShard.isDefined) {
-      rdd = rdd.splitField(conf.getSplitField.get).splitsPerShard(conf.getSplitsPerShard.get)
-    } else if (conf.getSplitField.isDefined) {
+    if (conf.splits.isDefined) {
+      rdd = rdd.doSplits()
+
+      if (!conf.getSplitsPerShard.isDefined) {
+        // user wants splits, but didn't specify how many per shard
+        rdd = rdd.splitsPerShard(DEFAULT_SPLITS_PER_SHARD)
+      }
+    }
+
+    if (conf.getSplitField.isDefined) {
       rdd = rdd.splitField(conf.getSplitField.get)
+
+      if (!conf.getSplitsPerShard.isDefined) {
+        // user wants splits, but didn't specify how many per shard
+        rdd = rdd.splitsPerShard(DEFAULT_SPLITS_PER_SHARD)
+      }
     }
 
     rdd
@@ -282,8 +295,7 @@ class SolrRelation(
       }
     }
 
-    logInfo("Fields passed down from scanner: " + fields.mkString(","))
-    logInfo("Filters passed down from scanner: " + filters.mkString(","))
+    logInfo("push-down fields: [" + fields.mkString(",") + "], filters: ["+filters.mkString(",")+"]")
 
     // this check is probably unnecessary, but I'm putting it here so that it's clear to other devs
     // that the baseSchema must be defined if we get to this point
@@ -316,8 +328,6 @@ class SolrRelation(
       query.add(ConfigurationConstants.SAMPLE_PCT, conf.samplePct.getOrElse(0.1f).toString)
     }
 
-    logInfo(s"Constructed SolrQuery: ${query}")
-
     try {
       val querySchema = if (!fields.isEmpty) SolrRelationUtil.deriveQuerySchema(fields, collectionBaseSchema) else schema
 
@@ -326,7 +336,7 @@ class SolrRelation(
       }
 
       if (rq.isEmpty && !conf.useCursorMarks.getOrElse(false)) {
-        logDebug(s"Checking the query and sort fields to determine if streaming is possible for ${collection}")
+        logInfo(s"Checking the query and sort fields to determine if streaming is possible for ${collection}")
         // Determine whether to use Streaming API (/export handler) if 'use_export_handler' or 'use_cursor_marks' options are not set
         val hasUnsupportedExportTypes : Boolean = SolrRelation.checkQueryFieldsForUnsupportedExportTypes(querySchema)
         val isFDV: Boolean = SolrRelation.checkQueryFieldsForDV(querySchema)
@@ -339,15 +349,21 @@ class SolrRelation(
           val sortParams = query.getParams(CommonParams.SORT)
           if (sortParams != null && sortParams.nonEmpty) {
             for (sortString <- sortParams) {
-              val sortStringParams = sortString.split(" ")
-              if (sortStringParams.nonEmpty && sortStringParams.size == 2) {
-                sortClauses += new SortClause(sortStringParams(0), sortStringParams(1))
+              for (pair <- sortString.split(",")) {
+                val sortStringParams = pair.split(" ")
+                if (sortStringParams.nonEmpty) {
+                  if (sortStringParams.size == 2) {
+                    sortClauses += new SortClause(sortStringParams(0), sortStringParams(1))
+                  } else {
+                    sortClauses += SortClause.asc(pair)
+                  }
+                }
               }
             }
           }
         }
 
-        logDebug(s"Existing sort clauses: ${sortClauses.mkString}")
+        logInfo(s"Existing sort clauses: ${sortClauses.mkString}")
         val isSDV: Boolean =
           if (sortClauses.nonEmpty)
             SolrRelation.checkSortFieldsForDV(collectionBaseSchema, sortClauses.toList)
@@ -366,10 +382,12 @@ class SolrRelation(
         } else {
           logDebug(s"Using requestHandler: $rq isFDV? $isFDV and isSDV? $isSDV and hasUnsupportedExportTypes? $hasUnsupportedExportTypes")
         }
+        logInfo(s"Sending ${query} to SolrRDD using ${requestHandler}")
         val docs = solrRDD.requestHandler(requestHandler).query(query)
         val rows = SolrRelationUtil.toRows(querySchema, docs)
         rows
       } else {
+        logInfo(s"Sending ${query} to SolrRDD using ${rq}")
         val docs = solrRDD.query(query)
         val rows = SolrRelationUtil.toRows(querySchema, docs)
         rows

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -118,10 +118,10 @@ class SolrRDD(
       logInfo(s"rq = $rq, setting query defaults for query = $query uniqueKey = $uniqueKey")
       SolrQuerySupport.setQueryDefaultsForShards(query, uniqueKey)
       // Freeze the index by adding a filter query on _version_ field
-      val (min, max) = SolrQuerySupport.getNumericFieldStatsInfo(SolrSupport.getCachedCloudClient(zkHost), collection, query, DEFAULT_SPLIT_FIELD)
-      if (min.isDefined && max.isDefined) {
-        val rangeFilter = DEFAULT_SPLIT_FIELD + ":[" + min.get + " TO " + max.get + "]"
-        log.debug("range filter added to the query: " + rangeFilter)
+      val max = SolrQuerySupport.getMaxVersion(SolrSupport.getCachedCloudClient(zkHost), collection, query, DEFAULT_SPLIT_FIELD)
+      if (max.isDefined) {
+        val rangeFilter = DEFAULT_SPLIT_FIELD + ":[* TO " + max.get + "]"
+        logInfo("Range filter added to the query: " + rangeFilter)
         query.addFilterQuery(rangeFilter)
       }
     }

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -2,10 +2,10 @@ package com.lucidworks.spark.rdd
 
 import java.net.InetAddress
 
-import com.lucidworks.spark.query.{StreamingExpressionResultIterator, ResultsIterator, SolrStreamIterator, StreamingResultsIterator}
-import com.lucidworks.spark.util.{SolrQuerySupport, SolrSupport}
 import com.lucidworks.spark._
+import com.lucidworks.spark.query.{ResultsIterator, SolrStreamIterator, StreamingExpressionResultIterator, StreamingResultsIterator}
 import com.lucidworks.spark.util.QueryConstants._
+import com.lucidworks.spark.util.{SolrQuerySupport, SolrSupport}
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.common.SolrDocument
 import org.apache.spark._
@@ -113,9 +113,17 @@ class SolrRDD(
 
     val shards = SolrSupport.buildShardList(zkHost, collection)
     // Add defaults for shards. TODO: Move this for different implementations (Streaming)
+
     if (rq != QT_EXPORT) {
       logInfo(s"rq = $rq, setting query defaults for query = $query uniqueKey = $uniqueKey")
       SolrQuerySupport.setQueryDefaultsForShards(query, uniqueKey)
+      // Freeze the index by adding a filter query on _version_ field
+      val (min, max) = SolrQuerySupport.getNumericFieldStatsInfo(SolrSupport.getCachedCloudClient(zkHost), collection, query, DEFAULT_SPLIT_FIELD)
+      if (min.isDefined && max.isDefined) {
+        val rangeFilter = DEFAULT_SPLIT_FIELD + ":[" + min.get + " TO " + max.get + "]"
+        log.debug("range filter added to the query: " + rangeFilter)
+        query.addFilterQuery(rangeFilter)
+      }
     }
 
     val numReplicas = shards.apply(0).replicas.length

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -127,7 +127,7 @@ class SolrRDD(
     }
 
     val numReplicas = shards.apply(0).replicas.length
-    val numSplits = splitsPerShard.getOrElse(numReplicas)
+    val numSplits = splitsPerShard.getOrElse(2 * numReplicas)
     logInfo(s"Using splitField=${splitField}, splitsPerShard=${splitsPerShard}, and numReplicas=${numReplicas} for computing partitions.")
 
     val partitions : Array[Partition] = if (rq != QT_EXPORT && numSplits > 1) {

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -122,12 +122,12 @@ class SolrRDD(
     val numSplits = splitsPerShard.getOrElse(numReplicas)
     logInfo(s"Using splitField=${splitField}, splitsPerShard=${splitsPerShard}, and numReplicas=${numReplicas} for computing partitions.")
 
-    val partitions : Array[Partition] = if (splitField.isDefined) {
-      // split field is explicitly specified by the user
+    val partitions : Array[Partition] = if (rq != QT_EXPORT && splitField.isDefined) {
+      // split field is explicitly specified by the user ... but don't try splitting if the user is using /export
       SolrPartitioner.getSplitPartitions(shards, query, splitField.get, numSplits)
     } else {
-      // split field is not defined ... but if there are multiple replicas per shard, we should use them
-      if (numReplicas > 1 && numSplits > 1) {
+      // split field is not defined ... but if there are multiple replicas per shard, we should use them unless using /export which we don't want to split
+      if (rq != QT_EXPORT && numReplicas > 1 && numSplits > 1) {
         // multiple replicas available ... do at least one split per replica
         logInfo(s"Applied ${numSplits} intra-shard splits on the ${DEFAULT_SPLIT_FIELD} field for ${collection} to better utilize all active replicas. Set the 'split_field' option to override this behavior or set the 'splits_per_shard' option = 1 to disable splits per shard.")
         SolrPartitioner.getSplitPartitions(shards, query, DEFAULT_SPLIT_FIELD, numSplits)

--- a/src/main/scala/com/lucidworks/spark/util/QueryConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/QueryConstants.scala
@@ -10,7 +10,7 @@ object QueryConstants {
   val DEFAULT_REQUIRED_FIELD: String = "id"
   val DEFAULT_PAGE_SIZE: Int = 1000
   val DEFAULT_QUERY: String = "*:*"
-  val DEFAULT_SPLITS_PER_SHARD: Int = 20
+  val DEFAULT_SPLITS_PER_SHARD: Int = 10
   val DEFAULT_SPLIT_FIELD: String = "_version_"
   val DEFAULT_REQUEST_HANDLER: String = QT_SELECT
   val DEFAULT_TIME_STAMP_FIELD_NAME: String = "timestamp_tdt"

--- a/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
@@ -507,7 +507,7 @@ object SolrSupport extends Logging {
       splitsPerShard: Int): List[ShardSplit[_]] = {
 
     val hashSplitStrategy = new HashQParserShardSplitStrategy(solrShard)
-    logInfo(s"Creating $splitsPerShard splits using field $splitFieldName")
+    logDebug(s"Creating $splitsPerShard splits using field $splitFieldName for $solrShard")
     return hashSplitStrategy.getSplits(SolrRDD.randomReplicaLocation(solrShard), query, splitFieldName, splitsPerShard).toList
   }
 }

--- a/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
+++ b/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
@@ -74,7 +74,7 @@ public class RDDProcessorTestBase extends TestSolrCloudClusterSupport implements
     // index some docs into the new collection
     if (inputDocs != null) {
       int numDocsIndexed = indexDocs(zkHost, collection, inputDocs);
-      Thread.sleep(1000L);
+      SolrSupport.getCachedCloudClient(zkHost).commit(collection);
       // verify docs got indexed ... relies on soft auto-commits firing frequently
       SolrJavaRDD solrRDD = SolrJavaRDD.get(zkHost, collection, jsc.sc());
       JavaRDD<SolrDocument> resultsRDD = solrRDD.query("*:*");

--- a/src/test/java/com/lucidworks/spark/SolrRDDTest.java
+++ b/src/test/java/com/lucidworks/spark/SolrRDDTest.java
@@ -2,6 +2,8 @@ package com.lucidworks.spark;
 
 import com.lucidworks.spark.rdd.SolrJavaRDD;
 import com.lucidworks.spark.rdd.SolrRDD;
+import com.lucidworks.spark.util.ConfigurationConstants;
+import com.lucidworks.spark.util.QueryConstants;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.common.SolrDocument;
@@ -122,7 +124,8 @@ public class SolrRDDTest extends RDDProcessorTestBase {
         String queryStr = "q=*:*&sort=id&fq=field3_i:[2 TO 3]";
 
         SolrJavaRDD solrRDD = SolrJavaRDD.get(zkHost, testCollection, jsc.sc());
-        List<SolrDocument> docs = solrRDD.query(queryStr).collect();
+
+        List<SolrDocument> docs = solrRDD.queryNoSplits(queryStr).collect();
 
         assert docs.size() == 2;
         assert docs.get(0).get("id").equals(testCollection + "-2");

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -18,7 +18,7 @@ class EventsimTestSuite extends EventsimBuilder {
       .query("*:*")
       .rows(10)
       .select(Array("id"))
-    assert(solrRDD.getNumPartitions == numShards)
+    assert(solrRDD.getNumPartitions == numShards*2)
     testCommons(solrRDD)
   }
 

--- a/src/test/scala/com/lucidworks/spark/RDDTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/RDDTestSuite.scala
@@ -28,7 +28,7 @@ class RDDTestSuite extends TestSuiteBuilder with Logging {
     try {
       val newRDD = new SolrRDD(zkHost, collectionName, sc)
       val partitions = newRDD.partitions
-      assert(partitions.length === 4)
+      assert(partitions.length == 8)
     } finally {
       SolrCloudUtil.deleteCollection(collectionName, cluster)
     }


### PR DESCRIPTION
Couple things in here worth mentioning:

1) I think we should apply splits by default if there are multiple active replicas per shard so as to utilize both replicas in parallel. Previously, I had splits disabled by default because they had a cost to compute but with HashQParser, we can send queries to all replicas in parallel. If users want to disable splitting, they can set shards_per_split to 1. Of course, if the collection doesn't use replication, then this default split won't apply.

2) I changed the default splits to 10 if the user sets splits -> true but doesn't supply a value for splits_per_shard

3) You'll also notice that I'm applying the splits to the list of replicas using a loop vs. randomizer as I want to use all active replicas for a shard as is done with streaming expressions.

NOTE: I couldn't find any bugs in the sort handling as previously thought so thinking AO was using an older version?