### PR TITLE
Freeze the index using filter queries before querying any shards

### DIFF
--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -120,8 +120,9 @@ class SolrRDD(
       // Freeze the index by adding a filter query on _version_ field
       val (min, max) = SolrQuerySupport.getNumericFieldStatsInfo(SolrSupport.getCachedCloudClient(zkHost), collection, query, DEFAULT_SPLIT_FIELD)
       if (min.isDefined && max.isDefined) {
-        log.debug("min: " + min + " max: " + max)
-        query.addFilterQuery(DEFAULT_SPLIT_FIELD + ":[" + min.get + " TO " + max.get + "]")
+        val rangeFilter = DEFAULT_SPLIT_FIELD + ":[" + min.get + " TO " + max.get + "]"
+        log.debug("range filter added to the query: " + rangeFilter)
+        query.addFilterQuery(rangeFilter)
       }
     }
 

--- a/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
+++ b/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
@@ -74,7 +74,7 @@ public class RDDProcessorTestBase extends TestSolrCloudClusterSupport implements
     // index some docs into the new collection
     if (inputDocs != null) {
       int numDocsIndexed = indexDocs(zkHost, collection, inputDocs);
-      Thread.sleep(1000L);
+      SolrSupport.getCachedCloudClient(zkHost).commit(collection);
       // verify docs got indexed ... relies on soft auto-commits firing frequently
       SolrJavaRDD solrRDD = SolrJavaRDD.get(zkHost, collection, jsc.sc());
       JavaRDD<SolrDocument> resultsRDD = solrRDD.query("*:*");


### PR DESCRIPTION
* If the index is actively written to while the query is happening, the queries that use cursorMarks will fail. This PR restricts the query to the current index (as of query time) by adding filter queries on `_version_`. There is a slight overhead to this due to the 2 queries happening to determine the `_version_` min, max