### PR TITLE
Add option to skip non docValue fields

### DIFF
--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -238,4 +238,12 @@ class SolrConf(config: Map[String, String]) extends Serializable with Logging {
     if (config.contains(EXCLUDE_FIELDS) && config.get(EXCLUDE_FIELDS).isDefined) return config.get(EXCLUDE_FIELDS)
     None
   }
+
+  def skipNonDocValueFields: Option[Boolean] = {
+    if (config.contains(SKIP_NON_DOCVALUE_FIELDS) && config.get(SKIP_NON_DOCVALUE_FIELDS).isDefined) {
+      return Some(config.get(SKIP_NON_DOCVALUE_FIELDS).get.toBoolean)
+    }
+    None
+  }
+
 }

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -812,6 +812,7 @@ object SolrRelation extends Logging {
     })
   }
 
+  // TODO: remove this check when https://issues.apache.org/jira/browse/SOLR-9187 is fixed
   def checkQueryFieldsForUnsupportedExportTypes(querySchema: StructType) : Boolean = {
     for (structField <- querySchema.fields) {
       if (structField.dataType == BooleanType)

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -124,7 +124,8 @@ class SolrRelation(
                 conf.getZkHost.get,
                 sf.collection,
                 conf.escapeFieldNames.getOrElse(false),
-                conf.flattenMultivalued.getOrElse(true))
+                conf.flattenMultivalued.getOrElse(true),
+                conf.skipNonDocValueFields.getOrElse(false))
             logDebug(s"Got stream schema: ${streamSchema} for ${sf}")
             sf.fields.foreach(fld => {
               val fieldName = fld.alias.getOrElse(fld.name)
@@ -275,7 +276,8 @@ class SolrRelation(
       conf.getZkHost.get,
       collection.split(",")(0),
       conf.escapeFieldNames.getOrElse(false),
-      conf.flattenMultivalued.getOrElse(true))
+      conf.flattenMultivalued.getOrElse(true),
+      conf.skipNonDocValueFields.getOrElse(false))
   }
 
   def findStreamingExpressionFields(expr: StreamExpressionParameter, streamOutputFields: ListBuffer[StreamFields], depth: Int) : Unit = {
@@ -810,7 +812,6 @@ object SolrRelation extends Logging {
     })
   }
 
-  // TODO: remove this check when https://issues.apache.org/jira/browse/SOLR-9187 is fixed
   def checkQueryFieldsForUnsupportedExportTypes(querySchema: StructType) : Boolean = {
     for (structField <- querySchema.fields) {
       if (structField.dataType == BooleanType)

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -13,6 +13,7 @@ object ConfigurationConstants {
   val SOLR_SPLIT_FIELD_PARAM: String = "split_field"
   val SOLR_SPLITS_PER_SHARD_PARAM: String = "splits_per_shard"
   val ESCAPE_FIELDNAMES_PARAM: String = "escape_fieldnames"
+  val SKIP_NON_DOCVALUE_FIELDS: String = "skip_non_dv"
   val SOLR_DOC_VALUES: String = "dv"
   val FLATTEN_MULTIVALUED: String = "flatten_multivalued"
   @deprecated

--- a/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
@@ -636,7 +636,7 @@ object SolrQuerySupport extends Logging {
       pivotFields: Array[PivotField],
       solrRDD: SolrRDD,
       escapeFieldNames: Boolean): DataFrame = {
-    val schema = SolrRelationUtil.getBaseSchema(solrRDD.zkHost, solrRDD.collection, escapeFieldNames, true)
+    val schema = SolrRelationUtil.getBaseSchema(solrRDD.zkHost, solrRDD.collection, escapeFieldNames, true, false)
     val schemaWithPivots = toPivotSchema(solrData.schema, pivotFields, solrRDD.collection, schema, solrRDD.uniqueKey, solrRDD.zkHost)
 
     val withPivotFields: RDD[Row] = solrData.rdd.map(row => {

--- a/src/test/java/com/lucidworks/spark/query/StreamingResultsIteratorTest.java
+++ b/src/test/java/com/lucidworks/spark/query/StreamingResultsIteratorTest.java
@@ -73,7 +73,7 @@ public class StreamingResultsIteratorTest extends RDDProcessorTestBase {
     Thread.sleep(2000);
 
     String uniqueKey = SolrQuerySupport.getUniqueKey(zkHost, testCollection);
-    StructType schema = SolrRelationUtil.getBaseSchema(zkHost, testCollection, false, true);
+    StructType schema = SolrRelationUtil.getBaseSchema(zkHost, testCollection, false, true, false);
     //StreamingResultsIterator sri = new StreamingResultsIterator(cloudSolrClient, solrQuery, "*");
     QueryResultsIterator sri = new QueryResultsIterator(cloudSolrClient, solrQuery, "*") ;
     int numDocsFound = 0;


### PR DESCRIPTION
Example:

```
val opts = Map("zkhost" -> zkHost, "collection" -> moviesCollection, skip_non_dv -> "true")
sqlContext.read.format("solr").options(opts).load()
```

The following code removes all the fields that do not have docValues from the schema