### PR TITLE
Do multiple requests to get schema of the dynamic fields

### DIFF
--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -81,7 +81,7 @@ class SolrRelation(
   val arbitraryParams = conf.getArbitrarySolrParams
   val solrFields: Array[String] = {
     if (arbitraryParams.getParameterNames.contains(CommonParams.FL)) {
-      arbitraryParams.getParams(CommonParams.FL)
+      arbitraryParams.getParams(CommonParams.FL).flatMap(f => f.split(",")).map(field => field.trim)
     } else {
       conf.getFields
     }

--- a/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
@@ -268,7 +268,7 @@ object SolrQuerySupport extends Logging {
     val fieldTypeToClassMap = getFieldTypeToClassMap(solrUrl)
     log.debug("Get field types for fields: {} ", fields.mkString(","))
     val fieldDefinitionsFromSchema = getFieldDefinitionsFromSchema(solrUrl, fields.toSeq)
-    fieldDefinitionsFromSchema.foreach {
+    fieldDefinitionsFromSchema.filterKeys(k => !k.startsWith("*_") && !k.endsWith("_*")).foreach {
       case(name, payloadRef) =>
       payloadRef match {
         case m: Map[_, _] if m.keySet.forall(_.isInstanceOf[String])=>

--- a/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
@@ -266,9 +266,8 @@ object SolrQuerySupport extends Logging {
   def getFieldTypes(fields: Set[String], solrUrl: String): Map[String, SolrFieldMeta] = {
     val fieldTypeMap = new mutable.HashMap[String, SolrFieldMeta]()
     val fieldTypeToClassMap = getFieldTypeToClassMap(solrUrl)
-    val fieldNames = if (fields == null || fields.isEmpty) getFieldsFromLuke(solrUrl) else fields
-    val fieldDefinitionsFromSchema = getFieldDefinitionsFromSchema(solrUrl, fieldNames)
-    fieldDefinitionsFromSchema.filterKeys(k => !k.startsWith("*_") && !k.endsWith("_*")).foreach {
+    val fieldDefinitionsFromSchema = getFieldDefinitionsFromSchema(solrUrl, fields)
+    fieldDefinitionsFromSchema.foreach {
       case(name, payloadRef) =>
       payloadRef match {
         case m: Map[_, _] if m.keySet.forall(_.isInstanceOf[String])=>

--- a/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
@@ -266,7 +266,7 @@ object SolrQuerySupport extends Logging {
   def getFieldTypes(fields: Set[String], solrUrl: String): Map[String, SolrFieldMeta] = {
     val fieldTypeMap = new mutable.HashMap[String, SolrFieldMeta]()
     val fieldTypeToClassMap = getFieldTypeToClassMap(solrUrl)
-    log.debug("Get field types for fields: " + fields.mkString(","))
+    log.debug("Get field types for fields: {} ", fields.mkString(","))
     val fieldDefinitionsFromSchema = getFieldDefinitionsFromSchema(solrUrl, fields.toSeq)
     fieldDefinitionsFromSchema.foreach {
       case(name, payloadRef) =>
@@ -375,7 +375,7 @@ object SolrQuerySupport extends Logging {
       fieldNames: Seq[String],
       fieldDefs: Map[String, Any] = Map.empty): Map[String, Any] = {
     val fieldsUrlBase = solrUrl + "schema/fields?showDefaults=true&includeDynamic=true"
-    log.debug("Requesting schema for fields: " + fieldNames.mkString(","))
+    log.debug("Requesting schema for fields: {} ", fieldNames.mkString(","))
 
     if (fieldNames.isEmpty && fieldDefs.isEmpty)
       return fetchFieldSchemaInfoFromSolr(fieldsUrlBase)

--- a/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
@@ -362,6 +362,14 @@ object SolrQuerySupport extends Logging {
     fieldTypeMap.toMap
   }
 
+  /**
+   * Do multiple requests if the length of url exceeds limit size (2048).
+   * We need this to retrieve schema of dynamic fields
+   * @param solrUrl
+   * @param fieldNames
+   * @param fieldDefs
+   * @return
+   */
   def getFieldDefinitionsFromSchema(
       solrUrl: String,
       fieldNames: Seq[String],

--- a/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
@@ -266,7 +266,8 @@ object SolrQuerySupport extends Logging {
   def getFieldTypes(fields: Set[String], solrUrl: String): Map[String, SolrFieldMeta] = {
     val fieldTypeMap = new mutable.HashMap[String, SolrFieldMeta]()
     val fieldTypeToClassMap = getFieldTypeToClassMap(solrUrl)
-    val fieldDefinitionsFromSchema = getFieldDefinitionsFromSchema(solrUrl, fields)
+    log.debug("Get field types for fields: " + fields.mkString(","))
+    val fieldDefinitionsFromSchema = getFieldDefinitionsFromSchema(solrUrl, fields.toSeq)
     fieldDefinitionsFromSchema.foreach {
       case(name, payloadRef) =>
       payloadRef match {
@@ -361,32 +362,37 @@ object SolrQuerySupport extends Logging {
     fieldTypeMap.toMap
   }
 
-  def getFieldDefinitionsFromSchema(solrUrl: String, fieldNames: Set[String]): Map[String, Any] = {
-    val fl: Option[String] = if (fieldNames.nonEmpty) {
-      val sb = new StringBuilder
-      sb.append("&fl=")
-      fieldNames.zipWithIndex.foreach{ case(name, index) =>
-        sb.append(name)
-        if (index < fieldNames.size) sb.append(",")
-      }
-      Some(sb.toString())
-    } else None
-
+  def getFieldDefinitionsFromSchema(
+      solrUrl: String,
+      fieldNames: Seq[String],
+      fieldDefs: Map[String, Any] = Map.empty): Map[String, Any] = {
     val fieldsUrlBase = solrUrl + "schema/fields?showDefaults=true&includeDynamic=true"
-    val flList = fl.getOrElse("")
-    if (flList.length > (2048 - fieldsUrlBase.length)) {
-      val fieldDefs = scala.collection.mutable.HashMap.empty[String,Any]
-      // go get all fields from Solr and then prune from there
-      val allFields = fetchFieldSchemaInfoFromSolr(fieldsUrlBase)
-      fieldNames.foreach(fname => {
-        if (allFields.containsKey(fname)) {
-          fieldDefs.put(fname, allFields.get(fname).get)
-        }
-      })
-      fieldDefs.toMap
-    } else {
-      fetchFieldSchemaInfoFromSolr(fieldsUrlBase+flList)
+    log.debug("Requesting schema for fields: " + fieldNames.mkString(","))
+
+    if (fieldNames.isEmpty && fieldDefs.isEmpty)
+      return fetchFieldSchemaInfoFromSolr(fieldsUrlBase)
+
+    if (fieldNames.isEmpty && fieldDefs.nonEmpty)
+      return fieldDefs
+
+    val allowedUrlLimit = 2048 - fieldsUrlBase.length
+    var flLength = 0
+    val sb = new StringBuilder()
+    sb.append("&fl=")
+
+    for (i <- fieldNames.indices) {
+      val fieldName = fieldNames(i)
+      if (flLength + fieldName.length + 1 < allowedUrlLimit) {
+        sb.append(fieldName)
+        if (i < fieldNames.size) sb.append(",")
+        flLength = flLength + fieldName.length + 1
+      } else {
+        val defs: Map[String, Any] = fetchFieldSchemaInfoFromSolr(fieldsUrlBase + sb.toString())
+        return getFieldDefinitionsFromSchema(fieldsUrlBase, fieldNames.takeRight(fieldNames.length - i), defs ++ fieldDefs)
+      }
     }
+    val defs = fetchFieldSchemaInfoFromSolr(fieldsUrlBase + sb.toString())
+    getFieldDefinitionsFromSchema(fieldsUrlBase, Seq.empty, defs ++ fieldDefs)
   }
 
   def fetchFieldSchemaInfoFromSolr(fieldsUrl: String) : Map[String, Any] = {

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -51,7 +51,7 @@ object SolrRelationUtil extends Logging {
     val solrBaseUrl = SolrSupport.getSolrBaseUrl(zkHost)
     val solrUrl = solrBaseUrl + collection + "/"
     val fieldsFromLuke = SolrQuerySupport.getFieldsFromLuke(solrUrl)
-    log.debug("Fields from luke handler: " + fieldsFromLuke.mkString(","))
+    log.debug("Fields from luke handler: {}", fieldsFromLuke.mkString(","))
     if (fieldsFromLuke.isEmpty)
       return new StructType()
 
@@ -60,7 +60,7 @@ object SolrRelationUtil extends Logging {
         SolrQuerySupport.getFieldTypes(fieldsFromLuke, solrUrl)
       else
         SolrQuerySupport.getFieldTypes(fields, solrUrl)
-    log.debug("Fields from schema handler " + fieldTypeMap.keySet.mkString(","))
+    log.debug("Fields from schema handler: {}", fieldTypeMap.keySet.mkString(","))
     val structFields = new ListBuffer[StructField]
 
     // Retain the keys that are present in the Luke handler

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -63,7 +63,7 @@ object SolrRelationUtil extends Logging {
     log.debug("Fields from schema handler " + fieldTypeMap.keySet.mkString(","))
     val structFields = new ListBuffer[StructField]
 
-    // keep only keys that are present in the Luke handler
+    // Retain the keys that are present in the Luke handler
     fieldTypeMap.filterKeys(f => fieldsFromLuke.contains(f)).foreach{ case(fieldName, fieldMeta) =>
       val metadata = new MetadataBuilder
       var dataType: DataType = {

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -51,11 +51,16 @@ object SolrRelationUtil extends Logging {
     val solrBaseUrl = SolrSupport.getSolrBaseUrl(zkHost)
     val solrUrl = solrBaseUrl + collection + "/"
     val fieldsFromLuke = SolrQuerySupport.getFieldsFromLuke(solrUrl)
+    log.debug("Fields from luke handler: " + fieldsFromLuke.mkString(","))
     if (fieldsFromLuke.isEmpty)
       return new StructType()
 
-    val fieldTypeMap = SolrQuerySupport.getFieldTypes(fieldsFromLuke, solrUrl)
-
+    val fieldTypeMap =
+      if (fields.isEmpty)
+        SolrQuerySupport.getFieldTypes(fieldsFromLuke, solrUrl)
+      else
+        SolrQuerySupport.getFieldTypes(fields, solrUrl)
+    log.debug("Fields from schema handler " + fieldTypeMap.keySet.mkString(","))
     val structFields = new ListBuffer[StructField]
 
     // keep only keys that are present in the Luke handler

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -49,10 +49,17 @@ object SolrRelationUtil extends Logging {
       return new StructType()
 
     val solrBaseUrl = SolrSupport.getSolrBaseUrl(zkHost)
-    val fieldTypeMap = SolrQuerySupport.getFieldTypes(fields, solrBaseUrl, collection)
+    val solrUrl = solrBaseUrl + collection + "/"
+    val fieldsFromLuke = SolrQuerySupport.getFieldsFromLuke(solrUrl)
+    if (fieldsFromLuke.isEmpty)
+      return new StructType()
+
+    val fieldTypeMap = SolrQuerySupport.getFieldTypes(fieldsFromLuke, solrUrl)
+
     val structFields = new ListBuffer[StructField]
 
-    fieldTypeMap.foreach{ case(fieldName, fieldMeta) =>
+    // keep only keys that are present in the Luke handler
+    fieldTypeMap.filterKeys(f => fieldsFromLuke.contains(f)).foreach{ case(fieldName, fieldMeta) =>
       val metadata = new MetadataBuilder
       var dataType: DataType = {
         if (fieldMeta.fieldTypeClass.isDefined) {


### PR DESCRIPTION
* If a lot of dynamic fields exist in the Luke handler, do multiple requests to get the schema information for all those fields. (Previously, we didn't support schema for dynamic fields if the url size exceeded 2048)
* Schema should only have fields that are populated in the Luke handler