### PR TITLE
SPAR-43 Treat 'score' field as a special property and custom sql schema

### DIFF
--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -234,6 +234,11 @@ class SolrConf(config: Map[String, String]) extends Serializable with Logging {
     None
   }
 
+  def getSolrSQLSchema: Option[String] = {
+    if (config.contains(SOLR_SQL_SCHEMA) && config.get(SOLR_SQL_SCHEMA).isDefined) return config.get(SOLR_SQL_SCHEMA)
+    None
+  }
+
   def getExcludeFields: Option[String] = {
     if (config.contains(EXCLUDE_FIELDS) && config.get(EXCLUDE_FIELDS).isDefined) return config.get(EXCLUDE_FIELDS)
     None

--- a/src/main/scala/com/lucidworks/spark/SolrSQLHiveContext.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrSQLHiveContext.scala
@@ -1,16 +1,15 @@
 package com.lucidworks.spark
 
-import java.util.{Collections, Locale}
+import java.security.AccessControlException
+import java.util.Locale
 import java.util.regex.{Matcher, Pattern}
 
 import com.lucidworks.spark.query.sql.SolrSQLSupport
 import org.apache.commons.codec.digest.DigestUtils
 import org.apache.hadoop.security.UserGroupInformation
-import org.apache.spark.sql.{SQLContext, DataFrame}
 import org.apache.spark.sql.hive.HiveContext
+import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.{Logging, SparkContext}
-
-import java.security.AccessControlException
 
 import scala.collection.JavaConversions.mapAsScalaMap
 
@@ -127,7 +126,7 @@ class SolrSQLHiveContext(sparkContext: SparkContext,
     }
 
     // Determine if the columns in the query are compatible with Solr SQL
-    val cols = SolrSQLHiveContext.parseColumns(sqlText).getOrElse(return sqlText)
+    val cols = SolrSQLHiveContext.parseColumns(solrQueryStmt).getOrElse(return sqlText)
     logDebug("Parsed columns: " + cols)
     logInfo(s"Attempting to push-down sub-query into Solr: ${solrQueryStmt}")
 

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -45,5 +45,6 @@ object ConfigurationConstants {
   val ARBITRARY_PARAMS_STRING: String = "solr.params"
 
   val STREAMING_EXPR_SCHEMA: String = "expr_schema"
+  val SOLR_SQL_SCHEMA: String = "sql_schema"
   val EXCLUDE_FIELDS: String = "exclude_fields"
 }

--- a/src/test/scala/com/lucidworks/spark/MovieLensTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/MovieLensTestSuite.scala
@@ -1,0 +1,42 @@
+package com.lucidworks.spark
+
+import com.lucidworks.spark.util.{QueryConstants, ConfigurationConstants}
+import org.apache.spark.sql.types.DoubleType
+
+class MovieLensTestSuite extends MovielensBuilder {
+
+  test("Score column in SQL statement pushdown to Solr") {
+    val sqlStmt = "SELECT movie_id,title,score from movielens_movies where _query_='title_txt_en:dog' order by score desc LIMIT 100"
+    val opts = Map(
+      "zkhost" -> zkHost,
+      "collection" -> moviesColName,
+      ConfigurationConstants.REQUEST_HANDLER -> QueryConstants.QT_SQL,
+      ConfigurationConstants.SOLR_SQL_STMT -> sqlStmt)
+    val df = sqlContext.read.format("solr").options(opts).load()
+
+    val schema = df.schema
+    assert (schema.fieldNames.contains("score"))
+    assert (schema("score").dataType == DoubleType)
+    val rows = df.take(10)
+    assert(rows(0).length==3)
+  }
+
+  test("Provide SQL schema via config") {
+    val sqlStmt = "SELECT movie_id,title,score from movielens_movies where _query_='title_txt_en:dog' order by score desc LIMIT 100"
+    val sqlSchema = "movie_id:string,title:string,score:double"
+    val opts = Map(
+      "zkhost" -> zkHost,
+      "collection" -> moviesColName,
+      ConfigurationConstants.REQUEST_HANDLER -> QueryConstants.QT_SQL,
+      ConfigurationConstants.SOLR_SQL_STMT -> sqlStmt,
+      ConfigurationConstants.SOLR_SQL_SCHEMA -> sqlSchema)
+    val df = sqlContext.read.format("solr").options(opts).load()
+
+    val schema = df.schema
+    assert (schema.fieldNames.contains("score"))
+    assert (schema("score").dataType == DoubleType)
+    val rows = df.take(10)
+    assert(rows(0).length==3)
+  }
+
+}


### PR DESCRIPTION
* 'score' field in 'sql' statement will be considered as a double 
* Config property `sql_schema` can be used to specify custom schema for Solr SQL statements