### PR TITLE
Use Javabin for SolrStream iterator

### DIFF
--- a/src/main/java/com/lucidworks/spark/query/SolrStreamIterator.java
+++ b/src/main/java/com/lucidworks/spark/query/SolrStreamIterator.java
@@ -37,6 +37,7 @@ public class SolrStreamIterator extends TupleStreamIterator {
       solrQuery = solrQuery.setRequestHandler("/export");
     }
     solrQuery.setRows(null);
+    solrQuery.set(CommonParams.WT, CommonParams.JAVABIN);
     //SolrQuerySupport.validateExportHandlerQuery(solrServer, solrQuery);
   }
 


### PR DESCRIPTION
Take advantage of SOLR-9721. Improves the performance of `/export` handler 