### PR TITLE
SPAR-42 Parameterize SolrRDD and avoid conversions between Tuple and SolrDocument

### DIFF
--- a/src/main/java/com/lucidworks/spark/query/ResultsIterator.java
+++ b/src/main/java/com/lucidworks/spark/query/ResultsIterator.java
@@ -1,10 +1,8 @@
 package com.lucidworks.spark.query;
 
-import org.apache.solr.common.SolrDocument;
-
 import java.util.Iterator;
 
-public abstract class ResultsIterator implements Iterator<SolrDocument>, Iterable<SolrDocument> {
+public abstract class ResultsIterator<E> implements Iterator<E>, Iterable<E> {
 
   public abstract long getNumDocs();
 

--- a/src/main/java/com/lucidworks/spark/query/StreamingExpressionResultIterator.java
+++ b/src/main/java/com/lucidworks/spark/query/StreamingExpressionResultIterator.java
@@ -25,8 +25,6 @@ public class StreamingExpressionResultIterator extends TupleStreamIterator {
   protected String collection;
   protected String qt;
 
-  protected Set<String> promoteToDoubleFields = Collections.EMPTY_SET;
-
   private final Random random = new Random(5150L);
 
   public StreamingExpressionResultIterator(String zkHost, String collection, SolrParams solrParams) {
@@ -36,14 +34,6 @@ public class StreamingExpressionResultIterator extends TupleStreamIterator {
 
     qt = solrParams.get(CommonParams.QT);
     if (qt == null) qt = "/stream";
-
-    if ("/sql".equals(qt) || "/stream".equals(qt)) {
-      String promoteToDoubleFieldList = solrParams.get("promote_to_double");
-      if (promoteToDoubleFieldList != null) {
-        promoteToDoubleFields = new HashSet<>();
-        promoteToDoubleFields.addAll(Arrays.asList(promoteToDoubleFieldList.split(",")));
-      }
-    }
   }
 
 
@@ -89,22 +79,6 @@ public class StreamingExpressionResultIterator extends TupleStreamIterator {
       }
     }
     return stream;
-  }
-
-  // need to override to promote Long to Double for some fields (see SOLR-9372)
-  @Override
-  protected SolrDocument tuple2doc(Tuple tuple) {
-    final SolrDocument doc = new SolrDocument();
-    for (Object key : tuple.fields.keySet()) {
-      String keyStr = (String) key;
-      Object value = tuple.get(key);
-      if (value instanceof Number && promoteToDoubleFields.contains(keyStr)) {
-        doc.setField(keyStr, ((Number)value).doubleValue());
-      } else {
-        doc.setField(keyStr, value);
-      }
-    }
-    return doc;
   }
 
   protected Replica getRandomReplica() {

--- a/src/main/java/com/lucidworks/spark/query/StreamingResultsIterator.java
+++ b/src/main/java/com/lucidworks/spark/query/StreamingResultsIterator.java
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * An iterator over a stream of query results from Solr.
  */
-public class StreamingResultsIterator extends ResultsIterator {
+public class StreamingResultsIterator extends ResultsIterator<SolrDocument> {
 
   private static Logger log = Logger.getLogger(StreamingResultsIterator.class);
 

--- a/src/main/java/com/lucidworks/spark/query/TupleStreamIterator.java
+++ b/src/main/java/com/lucidworks/spark/query/TupleStreamIterator.java
@@ -16,7 +16,7 @@ import java.util.NoSuchElementException;
  * This iterator is not thread safe. It is intended to be used within the
  * context of a single thread.
  */
-public abstract class TupleStreamIterator extends ResultsIterator {
+public abstract class TupleStreamIterator extends ResultsIterator<Tuple> {
 
   private static final Logger log = Logger.getLogger(TupleStreamIterator.class);
 
@@ -100,8 +100,8 @@ public abstract class TupleStreamIterator extends ResultsIterator {
     return tempCurrentTuple;
   }
 
-  public synchronized SolrDocument next() {
-    return tuple2doc(nextTuple());
+  public synchronized Tuple next() {
+    return nextTuple();
   }
 
   protected SolrDocument tuple2doc(Tuple tuple) {
@@ -116,7 +116,7 @@ public abstract class TupleStreamIterator extends ResultsIterator {
     throw new UnsupportedOperationException("remove is not supported");
   }
 
-  public Iterator<SolrDocument> iterator() {
+  public Iterator<Tuple> iterator() {
     return this;
   }
 

--- a/src/main/java/com/lucidworks/spark/query/TupleStreamIterator.java
+++ b/src/main/java/com/lucidworks/spark/query/TupleStreamIterator.java
@@ -8,6 +8,7 @@ import org.apache.solr.common.params.SolrParams;
 
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 /**
@@ -16,7 +17,7 @@ import java.util.NoSuchElementException;
  * This iterator is not thread safe. It is intended to be used within the
  * context of a single thread.
  */
-public abstract class TupleStreamIterator extends ResultsIterator<Tuple> {
+public abstract class TupleStreamIterator extends ResultsIterator<Map> {
 
   private static final Logger log = Logger.getLogger(TupleStreamIterator.class);
 
@@ -87,7 +88,7 @@ public abstract class TupleStreamIterator extends ResultsIterator<Tuple> {
 
   protected abstract TupleStream openStream();
 
-  public synchronized Tuple nextTuple() {
+  public synchronized Map nextTuple() {
     if (isClosed)
       throw new NoSuchElementException("already closed");
 
@@ -97,10 +98,10 @@ public abstract class TupleStreamIterator extends ResultsIterator<Tuple> {
     final Tuple tempCurrentTuple = currentTuple;
     currentTuple = null;
     ++numDocs;
-    return tempCurrentTuple;
+    return tempCurrentTuple.getMap();
   }
 
-  public synchronized Tuple next() {
+  public synchronized Map next() {
     return nextTuple();
   }
 
@@ -116,7 +117,7 @@ public abstract class TupleStreamIterator extends ResultsIterator<Tuple> {
     throw new UnsupportedOperationException("remove is not supported");
   }
 
-  public Iterator<Tuple> iterator() {
+  public Iterator<Map> iterator() {
     return this;
   }
 

--- a/src/main/java/com/lucidworks/spark/query/TupleStreamIterator.java
+++ b/src/main/java/com/lucidworks/spark/query/TupleStreamIterator.java
@@ -105,14 +105,6 @@ public abstract class TupleStreamIterator extends ResultsIterator<Map> {
     return nextTuple();
   }
 
-  protected SolrDocument tuple2doc(Tuple tuple) {
-    final SolrDocument doc = new SolrDocument();
-    for (Object key : tuple.fields.keySet()) {
-      doc.setField((String) key, tuple.get(key));
-    }
-    return doc;
-  }
-
   public void remove() {
     throw new UnsupportedOperationException("remove is not supported");
   }

--- a/src/main/java/com/lucidworks/spark/rdd/SolrJavaRDD.java
+++ b/src/main/java/com/lucidworks/spark/rdd/SolrJavaRDD.java
@@ -20,23 +20,23 @@ public class SolrJavaRDD extends JavaRDD<SolrDocument> {
   }
 
   public JavaRDD<SolrDocument> query(String query) {
-    return wrap((SelectSolrRDD) rdd().query(query));
+    return wrap(rdd().query(query));
   }
 
   public JavaRDD<SolrDocument> queryShards(String query) {
-    return wrap((SelectSolrRDD) rdd().query(query));
+    return wrap(rdd().query(query));
   }
 
   public JavaRDD<SolrDocument> queryShards(SolrQuery solrQuery) {
-    return wrap((SelectSolrRDD) rdd().query(solrQuery));
+    return wrap(rdd().query(solrQuery));
   }
 
   public JavaRDD<SolrDocument> queryShards(SolrQuery solrQuery, String splitFieldName, int splitsPerShard) {
-    return wrap((SelectSolrRDD) ((SelectSolrRDD)((SelectSolrRDD) rdd().query(solrQuery)).splitField(splitFieldName)).splitsPerShard(splitsPerShard));
+    return wrap(rdd().query(solrQuery).splitField(splitFieldName).splitsPerShard(splitsPerShard));
   }
 
   public JavaRDD<SolrDocument> queryNoSplits(String query) {
-    return wrap((SelectSolrRDD) ((SelectSolrRDD) rdd().query(query)).splitsPerShard(1));
+    return wrap(rdd().query(query).splitsPerShard(1));
   }
 
   @Override

--- a/src/main/java/com/lucidworks/spark/rdd/SolrJavaRDD.java
+++ b/src/main/java/com/lucidworks/spark/rdd/SolrJavaRDD.java
@@ -11,7 +11,7 @@ public class SolrJavaRDD extends JavaRDD<SolrDocument> {
   private final SelectSolrRDD solrRDD;
 
   public SolrJavaRDD(SelectSolrRDD solrRDD) {
-    super(solrRDD, JavaApiHelper.getClassTag(SolrDocument.class));
+    super(solrRDD, solrRDD.elementClassTag());
     this.solrRDD = solrRDD;
   }
 

--- a/src/main/java/com/lucidworks/spark/rdd/SolrJavaRDD.java
+++ b/src/main/java/com/lucidworks/spark/rdd/SolrJavaRDD.java
@@ -6,47 +6,46 @@ import org.apache.solr.common.SolrDocument;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 
-//TODO: Add all other methods from SolrRDD here
 public class SolrJavaRDD extends JavaRDD<SolrDocument> {
 
-  private final SolrRDD solrRDD;
+  private final SelectSolrRDD solrRDD;
 
-  public SolrJavaRDD(SolrRDD solrRDD) {
+  public SolrJavaRDD(SelectSolrRDD solrRDD) {
     super(solrRDD, JavaApiHelper.getClassTag(SolrDocument.class));
     this.solrRDD = solrRDD;
   }
 
-  protected SolrJavaRDD wrap(SolrRDD rdd) {
+  protected SolrJavaRDD wrap(SelectSolrRDD rdd) {
     return new SolrJavaRDD(rdd);
   }
 
   public JavaRDD<SolrDocument> query(String query) {
-    return wrap(rdd().query(query));
+    return wrap((SelectSolrRDD) rdd().query(query));
   }
 
   public JavaRDD<SolrDocument> queryShards(String query) {
-    return wrap(rdd().query(query));
+    return wrap((SelectSolrRDD) rdd().query(query));
   }
 
   public JavaRDD<SolrDocument> queryShards(SolrQuery solrQuery) {
-    return wrap(rdd().query(solrQuery));
+    return wrap((SelectSolrRDD) rdd().query(solrQuery));
   }
 
   public JavaRDD<SolrDocument> queryShards(SolrQuery solrQuery, String splitFieldName, int splitsPerShard) {
-    return wrap(rdd().query(solrQuery).splitField(splitFieldName).splitsPerShard(splitsPerShard));
+    return wrap((SelectSolrRDD) ((SelectSolrRDD)((SelectSolrRDD) rdd().query(solrQuery)).splitField(splitFieldName)).splitsPerShard(splitsPerShard));
   }
 
   public JavaRDD<SolrDocument> queryNoSplits(String query) {
-    return wrap(rdd().query(query).splitsPerShard(1));
+    return wrap((SelectSolrRDD) ((SelectSolrRDD) rdd().query(query)).splitsPerShard(1));
   }
 
   @Override
-  public SolrRDD rdd() {
+  public SelectSolrRDD rdd() {
     return solrRDD;
   }
 
   public static SolrJavaRDD get(String zkHost, String collection, SparkContext sc) {
-    SolrRDD solrRDD = SolrRDD$.MODULE$.apply(zkHost, collection, sc);
+    SelectSolrRDD solrRDD = SelectSolrRDD$.MODULE$.apply(zkHost, collection, sc);
     return new SolrJavaRDD(solrRDD);
   }
 

--- a/src/main/java/com/lucidworks/spark/rdd/SolrStreamJavaRDD.java
+++ b/src/main/java/com/lucidworks/spark/rdd/SolrStreamJavaRDD.java
@@ -2,16 +2,17 @@ package com.lucidworks.spark.rdd;
 
 import com.lucidworks.spark.util.JavaApiHelper;
 import org.apache.solr.client.solrj.SolrQuery;
-import org.apache.solr.client.solrj.io.Tuple;
 import org.apache.spark.SparkContext;
 import org.apache.spark.api.java.JavaRDD;
 
-public class SolrStreamJavaRDD extends JavaRDD<Tuple> {
+import java.util.Map;
+
+public class SolrStreamJavaRDD extends JavaRDD<Map<?,?>> {
 
   private final StreamingSolrRDD solrRDD;
 
   public SolrStreamJavaRDD(StreamingSolrRDD solrRDD) {
-    super(solrRDD, JavaApiHelper.getClassTag(Tuple.class));
+    super(solrRDD, solrRDD.elementClassTag());
     this.solrRDD = solrRDD;
   }
 
@@ -19,24 +20,24 @@ public class SolrStreamJavaRDD extends JavaRDD<Tuple> {
     return new SolrStreamJavaRDD(rdd);
   }
 
-  public JavaRDD<Tuple> query(String query) {
-    return wrap((StreamingSolrRDD) rdd().query(query));
+  public JavaRDD<Map<?,?>> query(String query) {
+    return wrap(rdd().query(query));
   }
 
-  public JavaRDD<Tuple> queryShards(String query) {
-    return wrap((StreamingSolrRDD) rdd().query(query));
+  public JavaRDD<Map<?,?>> queryShards(String query) {
+    return wrap(rdd().query(query));
   }
 
-  public JavaRDD<Tuple> queryShards(SolrQuery solrQuery) {
-    return wrap((StreamingSolrRDD) rdd().query(solrQuery));
+  public JavaRDD<Map<?,?>> queryShards(SolrQuery solrQuery) {
+    return wrap(rdd().query(solrQuery));
   }
 
-  public JavaRDD<Tuple> queryShards(SolrQuery solrQuery, String splitFieldName, int splitsPerShard) {
-    return wrap((StreamingSolrRDD) ((StreamingSolrRDD)((StreamingSolrRDD) rdd().query(solrQuery)).splitField(splitFieldName)).splitsPerShard(splitsPerShard));
+  public JavaRDD<Map<?,?>> queryShards(SolrQuery solrQuery, String splitFieldName, int splitsPerShard) {
+    return wrap(rdd().query(solrQuery).splitField(splitFieldName).splitsPerShard(splitsPerShard));
   }
 
-  public JavaRDD<Tuple> queryNoSplits(String query) {
-    return wrap((StreamingSolrRDD) ((StreamingSolrRDD) rdd().query(query)).splitsPerShard(1));
+  public JavaRDD<Map<?,?>> queryNoSplits(String query) {
+    return wrap(rdd().query(query).splitsPerShard(1));
   }
 
   @Override

--- a/src/main/java/com/lucidworks/spark/rdd/SolrStreamJavaRDD.java
+++ b/src/main/java/com/lucidworks/spark/rdd/SolrStreamJavaRDD.java
@@ -1,0 +1,52 @@
+package com.lucidworks.spark.rdd;
+
+import com.lucidworks.spark.util.JavaApiHelper;
+import org.apache.solr.client.solrj.SolrQuery;
+import org.apache.solr.client.solrj.io.Tuple;
+import org.apache.spark.SparkContext;
+import org.apache.spark.api.java.JavaRDD;
+
+public class SolrStreamJavaRDD extends JavaRDD<Tuple> {
+
+  private final StreamingSolrRDD solrRDD;
+
+  public SolrStreamJavaRDD(StreamingSolrRDD solrRDD) {
+    super(solrRDD, JavaApiHelper.getClassTag(Tuple.class));
+    this.solrRDD = solrRDD;
+  }
+
+  protected SolrStreamJavaRDD wrap(StreamingSolrRDD rdd) {
+    return new SolrStreamJavaRDD(rdd);
+  }
+
+  public JavaRDD<Tuple> query(String query) {
+    return wrap((StreamingSolrRDD) rdd().query(query));
+  }
+
+  public JavaRDD<Tuple> queryShards(String query) {
+    return wrap((StreamingSolrRDD) rdd().query(query));
+  }
+
+  public JavaRDD<Tuple> queryShards(SolrQuery solrQuery) {
+    return wrap((StreamingSolrRDD) rdd().query(solrQuery));
+  }
+
+  public JavaRDD<Tuple> queryShards(SolrQuery solrQuery, String splitFieldName, int splitsPerShard) {
+    return wrap((StreamingSolrRDD) ((StreamingSolrRDD)((StreamingSolrRDD) rdd().query(solrQuery)).splitField(splitFieldName)).splitsPerShard(splitsPerShard));
+  }
+
+  public JavaRDD<Tuple> queryNoSplits(String query) {
+    return wrap((StreamingSolrRDD) ((StreamingSolrRDD) rdd().query(query)).splitsPerShard(1));
+  }
+
+  @Override
+  public StreamingSolrRDD rdd() {
+    return solrRDD;
+  }
+
+  public static SolrStreamJavaRDD get(String zkHost, String collection, SparkContext sc) {
+    StreamingSolrRDD solrRDD = StreamingSolrRDD$.MODULE$.apply(zkHost, collection, sc);
+    return new SolrStreamJavaRDD(solrRDD);
+  }
+
+}

--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -121,13 +121,6 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
 
   def requestHandler: Option[String] = {
 
-    if (!config.contains(REQUEST_HANDLER) && config.contains(USE_EXPORT_HANDLER) && config.get(USE_EXPORT_HANDLER).isDefined) {
-      logger.warn(s"The ${USE_EXPORT_HANDLER} option is no longer supported, please switch to using the ${REQUEST_HANDLER} -> ${QT_EXPORT} option!")
-      if (config.get(USE_EXPORT_HANDLER).get.toBoolean) {
-        return Some(QT_EXPORT)
-      }
-    }
-
     if (!config.contains(REQUEST_HANDLER) && config.contains(SOLR_STREAMING_EXPR) && config.get(SOLR_STREAMING_EXPR).isDefined) {
       // they didn't specify a request handler but gave us an expression, so we know the request handler should be /stream
       logger.debug(s"Set ${REQUEST_HANDLER} to ${QT_STREAM} because the ${SOLR_STREAMING_EXPR} option is set.")

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -427,7 +427,7 @@ class SolrRelation(
         sqlContext.sparkContext,
         Some(qt),
         uKey = Some(uniqueKey)
-      ))
+      ).query(query))
 
     // this check is probably unnecessary, but I'm putting it here so that it's clear to other devs
     // that the baseSchema must be defined if we get to this point
@@ -703,7 +703,7 @@ class SolrRelation(
     }
     
     val sortParams = conf.getArbitrarySolrParams.remove("sort")
-    if (sortParams != null && sortParams.length > 0) {
+    if (sortParams != null && sortParams.nonEmpty) {
       for (p <- sortParams) {
         val sortClauses = SolrRelation.parseSortParamFromString(p)
         for (sortClause <- sortClauses) {
@@ -811,7 +811,6 @@ object SolrRelation extends LazyLogging {
     })
   }
 
-  // TODO: remove this check when https://issues.apache.org/jira/browse/SOLR-9187 is fixed
   def checkQueryFieldsForUnsupportedExportTypes(querySchema: StructType) : Boolean = {
     for (structField <- querySchema.fields) {
       if (structField.dataType == BooleanType)

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 import java.util.regex.Pattern
 
 import com.lucidworks.spark.query.sql.SolrSQLSupport
-import com.lucidworks.spark.rdd.SolrRDD
+import com.lucidworks.spark.rdd.{SolrRDD, StreamingSolrRDD}
 import com.lucidworks.spark.util.ConfigurationConstants._
 import com.lucidworks.spark.util.QueryConstants._
 import com.lucidworks.spark.util._
@@ -415,52 +415,19 @@ class SolrRelation(
   override def buildScan(): RDD[Row] = buildScan(Array.empty, Array.empty)
 
   override def buildScan(fields: Array[String], filters: Array[Filter]): RDD[Row] = {
-    
     logger.info("buildScan: push-down fields: [" + fields.mkString(",") + "], filters: ["+filters.mkString(",")+"]")
-
     val query = initialQuery.getCopy
     var qt = query.getRequestHandler
 
-    val solrRDD = {
-      var rdd = new SolrRDD(
+    // ignore any fields / filters when processing a streaming expression
+    if (qt == QT_STREAM || qt == QT_SQL)
+      return SolrRelationUtil.toRows(querySchema, new StreamingSolrRDD(
         conf.getZkHost.get,
         collection,
         sqlContext.sparkContext,
         Some(qt),
-        uKey = Some(uniqueKey))
-
-      if (conf.getSplitsPerShard.isDefined) {
-        // always apply this whether we're doing splits or not so that the user
-        // can pass splits_per_shard=1 to disable splitting when there are multiple replicas
-        // as we now will do splitting using the HashQParser when there are multiple active replicas
-        rdd = rdd.splitsPerShard(conf.getSplitsPerShard.get)
-      }
-
-      if (conf.splits.isDefined) {
-        rdd = rdd.doSplits()
-
-        if (!conf.getSplitsPerShard.isDefined) {
-          // user wants splits, but didn't specify how many per shard
-          rdd = rdd.splitsPerShard(DEFAULT_SPLITS_PER_SHARD)
-        }
-      }
-
-      if (conf.getSplitField.isDefined) {
-        rdd = rdd.splitField(conf.getSplitField.get)
-
-        if (!conf.getSplitsPerShard.isDefined) {
-          // user wants splits, but didn't specify how many per shard
-          rdd = rdd.splitsPerShard(DEFAULT_SPLITS_PER_SHARD)
-        }
-      }
-
-      rdd
-    }
-
-    if (qt == QT_STREAM || qt == QT_SQL) {
-      // ignore any fields / filters when processing a streaming expression
-      return SolrRelationUtil.toRows(querySchema, solrRDD.requestHandler(qt).query(query))
-    }
+        uKey = Some(uniqueKey)
+      ))
 
     // this check is probably unnecessary, but I'm putting it here so that it's clear to other devs
     // that the baseSchema must be defined if we get to this point
@@ -488,8 +455,8 @@ class SolrRelation(
         throw new IllegalStateException("Cannot do sampling if intra-shard splitting feature is enabled!");
       }
 
-      query.addSort(SolrQuery.SortClause.asc("random_"+conf.sampleSeed.get))
-      query.addSort(SolrQuery.SortClause.asc(solrRDD.uniqueKey))
+      query.addSort(SolrQuery.SortClause.asc("random_" + conf.sampleSeed.get))
+      query.addSort(SolrQuery.SortClause.asc(uniqueKey))
       query.add(ConfigurationConstants.SAMPLE_PCT, conf.samplePct.getOrElse(0.1f).toString)
     }
 
@@ -500,7 +467,11 @@ class SolrRelation(
         throw new IllegalStateException(s"No fields defined in query schema for query: ${query}. This is likely an issue with the Solr collection ${collection}, does it have data?")
       }
 
-      if (conf.requestHandler.isEmpty && !requiresExportHandler(qt) && !conf.useCursorMarks.getOrElse(false) && !conf.splits.getOrElse(false)) {
+      // Determine the request handler to use if not explicitly set by the user
+      if (conf.requestHandler.isEmpty &&
+          !requiresStreamingRDD(qt) &&
+          !conf.useCursorMarks.getOrElse(false) &&
+          !conf.splits.getOrElse(false)) {
         logger.info(s"Checking the query and sort fields to determine if streaming is possible for ${collection}")
         // Determine whether to use Streaming API (/export handler) if 'use_export_handler' or 'use_cursor_marks' options are not set
         val hasUnsupportedExportTypes : Boolean = SolrRelation.checkQueryFieldsForUnsupportedExportTypes(querySchema)
@@ -525,13 +496,13 @@ class SolrRelation(
           if (sortClauses.nonEmpty)
             SolrRelation.checkSortFieldsForDV(collectionBaseSchema, sortClauses.toList)
           else
-            if (isFDV && !hasUnsupportedExportTypes) {
-              SolrRelation.addSortField(querySchema, query)
-              logger.info("Added sort field '" + query.getSortField + "' to the query")
-              true
-            }
-            else
-              false
+          if (isFDV && !hasUnsupportedExportTypes) {
+            SolrRelation.addSortField(querySchema, query)
+            logger.info("Added sort field '" + query.getSortField + "' to the query")
+            true
+          }
+          else
+            false
 
         if (isFDV && isSDV && !hasUnsupportedExportTypes) {
           qt = QT_EXPORT
@@ -540,16 +511,28 @@ class SolrRelation(
         } else {
           logger.debug(s"Using requestHandler: $qt isFDV? $isFDV and isSDV? $isSDV and hasUnsupportedExportTypes? $hasUnsupportedExportTypes")
         }
-        // For DataFrame operations like count(), no fields are passed down but the export handler only works when fields are present
-        if (qt == QT_EXPORT) {
-          if (query.getFields == null)
-            query.setFields(solrRDD.uniqueKey)
-          if (query.getSorts.isEmpty && (query.getParams(CommonParams.SORT) == null || query.getParams(CommonParams.SORT).isEmpty))
-            query.setSort(solrRDD.uniqueKey, SolrQuery.ORDER.asc)
-        }
+      }
+
+      // For DataFrame operations like count(), no fields are passed down but the export handler only works when fields are present
+      if (qt == QT_EXPORT) {
+        if (query.getFields == null)
+          query.setFields(uniqueKey)
+        if (query.getSorts.isEmpty && (query.getParams(CommonParams.SORT) == null || query.getParams(CommonParams.SORT).isEmpty))
+          query.setSort(uniqueKey, SolrQuery.ORDER.asc)
       }
       logger.info(s"Sending ${query} to SolrRDD using ${qt}")
-      val docs = solrRDD.requestHandler(qt).query(query)
+
+      // Construct the SolrRDD based on the request handler
+      val solrRDD: SolrRDD[_] = SolrRDD.apply(
+        conf.getZkHost.get,
+        collection,
+        sqlContext.sparkContext,
+        Some(qt),
+        splitsPerShard = conf.getSplitsPerShard,
+        splitField = getSplitField(conf),
+        uKey = Some(uniqueKey))
+
+      val docs = solrRDD.query(query)
       val rows = SolrRelationUtil.toRows(querySchema, docs)
       rows
     } catch {
@@ -557,7 +540,13 @@ class SolrRelation(
     }
   }
 
-  def requiresExportHandler(rq: String): Boolean = {
+  def getSplitField(conf: SolrConf): Option[String] = {
+    if (conf.getSplitField.isDefined) conf.getSplitField
+    else if (conf.splits.getOrElse(false)) Some(DEFAULT_SPLIT_FIELD)
+    else None
+  }
+
+  def requiresStreamingRDD(rq: String): Boolean = {
     return rq == QT_EXPORT || rq == QT_STREAM || rq == QT_SQL
   }
 

--- a/src/main/scala/com/lucidworks/spark/example/NewRDDExample.scala
+++ b/src/main/scala/com/lucidworks/spark/example/NewRDDExample.scala
@@ -1,10 +1,10 @@
 package com.lucidworks.spark.example
 
-import com.lucidworks.spark.rdd.SolrRDD
 import com.lucidworks.spark.SparkApp
+import com.lucidworks.spark.rdd.SelectSolrRDD
 import com.lucidworks.spark.util.SolrSupport
 import com.typesafe.scalalogging.LazyLogging
-import org.apache.commons.cli.{Option, CommandLine}
+import org.apache.commons.cli.{CommandLine, Option}
 import org.apache.solr.client.solrj.request.CollectionAdminRequest
 import org.apache.spark.{SparkConf, SparkContext}
 
@@ -29,7 +29,7 @@ class NewRDDExample extends SparkApp.RDDProcessor with LazyLogging{
     cloudSolrClient.request(req)
 
     val sc = new SparkContext(conf)
-    val rdd = new SolrRDD(zkHost, collection, sc).query(queryStr)
+    val rdd = new SelectSolrRDD(zkHost, collection, sc).query(queryStr)
     val count = rdd.count()
 
     logger.info("Count is " + count)

--- a/src/main/scala/com/lucidworks/spark/example/RDDExample.scala
+++ b/src/main/scala/com/lucidworks/spark/example/RDDExample.scala
@@ -1,8 +1,8 @@
 package com.lucidworks.spark.example
 
-import com.lucidworks.spark.rdd.SolrRDD
-import com.lucidworks.spark.util.SolrSupport
 import com.lucidworks.spark.SparkApp
+import com.lucidworks.spark.rdd.SelectSolrRDD
+import com.lucidworks.spark.util.SolrSupport
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.cli.{CommandLine, Option}
 import org.apache.solr.client.solrj.request.CollectionAdminRequest
@@ -29,7 +29,7 @@ class RDDExample extends SparkApp.RDDProcessor with LazyLogging {
     cloudSolrClient.request(req)
 
     val sc = new SparkContext(conf)
-    val rdd = new SolrRDD(zkHost, collection, sc)
+    val rdd = new SelectSolrRDD(zkHost, collection, sc)
     val count = rdd.query(queryStr).count()
 
     logger.info("Count is " + count)

--- a/src/main/scala/com/lucidworks/spark/example/query/QueryBenchmark.scala
+++ b/src/main/scala/com/lucidworks/spark/example/query/QueryBenchmark.scala
@@ -1,13 +1,12 @@
 package com.lucidworks.spark.example.query
 
-import com.lucidworks.spark.rdd.SolrRDD
-import com.lucidworks.spark.util.SolrSupport
 import com.lucidworks.spark.SparkApp
-import org.apache.commons.cli.{Option, CommandLine}
+import com.lucidworks.spark.rdd.SelectSolrRDD
+import com.lucidworks.spark.util.SolrSupport
+import org.apache.commons.cli.{CommandLine, Option}
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.request.CollectionAdminRequest
-import org.apache.spark.SparkConf
-import org.apache.spark.SparkContext
+import org.apache.spark.{SparkConf, SparkContext}
 
 class QueryBenchmark extends SparkApp.RDDProcessor {
   def getName: String = "query-solr-benchmark"
@@ -42,7 +41,7 @@ class QueryBenchmark extends SparkApp.RDDProcessor {
     solrQuery.addSort(new SolrQuery.SortClause("id", "asc"))
     solrQuery.setRows(rows)
 
-    val solrRDD: SolrRDD = new SolrRDD(zkHost, collection, sc)
+    val solrRDD: SelectSolrRDD = new SelectSolrRDD(zkHost, collection, sc)
 
     var startMs: Long = System.currentTimeMillis
 

--- a/src/main/scala/com/lucidworks/spark/example/query/WordCount.scala
+++ b/src/main/scala/com/lucidworks/spark/example/query/WordCount.scala
@@ -1,7 +1,7 @@
 package com.lucidworks.spark.example.query
 
 import com.lucidworks.spark.SparkApp.RDDProcessor
-import com.lucidworks.spark.rdd.SolrRDD
+import com.lucidworks.spark.rdd.{SelectSolrRDD, SolrRDD}
 import com.lucidworks.spark.util.ConfigurationConstants._
 import org.apache.commons.cli.{CommandLine, Option}
 import org.apache.solr.common.SolrDocument
@@ -35,7 +35,7 @@ class WordCount extends RDDProcessor{
     val queryStr = cli.getOptionValue("query", "*:*")
 
     val sc = SparkContext.getOrCreate(conf)
-    val solrRDD: SolrRDD = new SolrRDD(zkHost, collection, sc)
+    val solrRDD: SelectSolrRDD = new SelectSolrRDD(zkHost, collection, sc)
     val rdd: RDD[SolrDocument]  = solrRDD.query(queryStr)
 
     val words: RDD[String] = rdd.map(doc => if (doc.containsKey("text_t")) doc.get("text_t").toString else "")

--- a/src/main/scala/com/lucidworks/spark/rdd/SelectSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SelectSolrRDD.scala
@@ -1,0 +1,105 @@
+package com.lucidworks.spark.rdd
+
+import com.lucidworks.spark.{SolrPartitioner, SolrRDDPartition}
+import com.lucidworks.spark.query.StreamingResultsIterator
+import com.lucidworks.spark.util.QueryConstants._
+import com.lucidworks.spark.util.{SolrQuerySupport, SolrSupport}
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.solr.client.solrj.SolrQuery
+import org.apache.solr.common.SolrDocument
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+
+import scala.collection.JavaConverters
+
+class SelectSolrRDD(
+    zkHost: String,
+    collection: String,
+    @transient sc: SparkContext,
+    requestHandler: Option[String] = None,
+    query : Option[String] = Option(DEFAULT_QUERY),
+    fields: Option[Array[String]] = None,
+    rows: Option[Int] = Option(DEFAULT_PAGE_SIZE),
+    splitField: Option[String] = None,
+    splitsPerShard: Option[Int] = None,
+    solrQuery: Option[SolrQuery] = None,
+    uKey: Option[String] = None)
+  extends SolrRDD[SolrDocument](zkHost, collection, sc)
+  with LazyLogging {
+
+  override type Self = SelectSolrRDD
+
+  protected def copy(
+    requestHandler: Option[String] = requestHandler,
+    query: Option[String] = query,
+    fields: Option[Array[String]] = fields,
+    rows: Option[Int] = rows,
+    splitField: Option[String] = splitField,
+    splitsPerShard: Option[Int] = splitsPerShard,
+    solrQuery: Option[SolrQuery] = solrQuery): Self = {
+      new SelectSolrRDD(zkHost, collection, sc, requestHandler, query, fields, rows, splitField, splitsPerShard, solrQuery, uKey)
+  }
+
+  @DeveloperApi
+  override def compute(split: Partition, context: TaskContext): Iterator[SolrDocument] = {
+    split match {
+      case partition: SolrRDDPartition =>
+        //TODO: Add backup mechanism to StreamingResultsIterator by being able to query any replica in case the main url goes down
+        val url = partition.preferredReplica.replicaUrl
+        val query = partition.query
+        logger.info("Using the shard url " + url + " for getting partition data for split: "+ split.index)
+        val solrRequestHandler = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)
+        query.setRequestHandler(solrRequestHandler)
+        logger.info("Using cursorMarks to fetch documents from "+partition.preferredReplica+" for query: "+partition.query)
+        val resultsIterator = new StreamingResultsIterator(SolrSupport.getHttpSolrClient(url), partition.query, partition.cursorMark)
+        context.addTaskCompletionListener { (context) =>
+          logger.info(f"Fetched ${resultsIterator.getNumDocs} rows from shard $url for partition ${split.index}")
+        }
+        JavaConverters.asScalaIteratorConverter(resultsIterator.iterator()).asScala
+
+      case partition: AnyRef => throw new Exception("Unknown partition type '" + partition.getClass)
+    }
+  }
+
+  override def getPartitions: Array[Partition] = {
+    val query = if (solrQuery.isEmpty) buildQuery else solrQuery.get
+    val rq = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)
+
+    val shards = SolrSupport.buildShardList(zkHost, collection)
+    logger.info(s"rq = $rq, setting query defaults for query = $query uniqueKey = $uniqueKey")
+    SolrQuerySupport.setQueryDefaultsForShards(query, uniqueKey)
+    // Freeze the index by adding a filter query on _version_ field
+    val max = SolrQuerySupport.getMaxVersion(SolrSupport.getCachedCloudClient(zkHost), collection, query, DEFAULT_SPLIT_FIELD)
+    if (max.isDefined) {
+      val rangeFilter = DEFAULT_SPLIT_FIELD + ":[* TO " + max.get + "]"
+      logger.info("Range filter added to the query: " + rangeFilter)
+      query.addFilterQuery(rangeFilter)
+    }
+
+    val numReplicas = shards.head.replicas.length
+    val numSplits = splitsPerShard.getOrElse(2 * numReplicas)
+    logger.info(s"Using splitField=$splitField, splitsPerShard=$splitsPerShard, and numReplicas=$numReplicas for computing partitions.")
+
+    val partitions : Array[Partition] = if (numSplits > 1) {
+      val splitFieldName = splitField.getOrElse(DEFAULT_SPLIT_FIELD)
+      logger.info(s"Applied $numSplits intra-shard splits on the $splitFieldName field for $collection to better utilize all active replicas. Set the 'split_field' option to override this behavior or set the 'splits_per_shard' option = 1 to disable splits per shard.")
+      SolrPartitioner.getSplitPartitions(shards, query, splitFieldName, numSplits)
+    } else {
+      // no explicit split field and only one replica || splits_per_shard was explicitly set to 1, no intra-shard splitting needed
+      SolrPartitioner.getShardPartitions(shards, query)
+    }
+
+    if (logger.underlying.isDebugEnabled) {
+      logger.debug(s"Found ${partitions.length} partitions: ${partitions.mkString(",")}")
+    } else {
+      logger.info(s"Found ${partitions.length} partitions.")
+    }
+    partitions
+  }
+}
+
+object SelectSolrRDD {
+  def apply(zkHost: String, collection: String, sparkContext: SparkContext): SelectSolrRDD = {
+    new SelectSolrRDD(zkHost, collection, sparkContext)
+  }
+}

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -1,23 +1,17 @@
 package com.lucidworks.spark.rdd
 
-import java.net.InetAddress
-
 import com.lucidworks.spark._
-import com.lucidworks.spark.query.{ResultsIterator, SolrStreamIterator, StreamingExpressionResultIterator, StreamingResultsIterator}
 import com.lucidworks.spark.util.QueryConstants._
-import com.lucidworks.spark.util.{SolrQuerySupport, SolrSupport}
+import com.lucidworks.spark.util.SolrQuerySupport
+import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.SolrQuery
-import org.apache.solr.common.SolrDocument
 import org.apache.spark._
-import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.rdd.RDD
 
-import com.typesafe.scalalogging.LazyLogging
-
-import scala.collection.JavaConverters
+import scala.reflect.ClassTag
 import scala.util.Random
 
-class SolrRDD(
+abstract class SolrRDD[T](
     val zkHost: String,
     val collection: String,
     @transient sc: SparkContext,
@@ -29,10 +23,10 @@ class SolrRDD(
     splitsPerShard: Option[Int] = None,
     solrQuery: Option[SolrQuery] = None,
     uKey: Option[String] = None)
-  extends RDD[SolrDocument](sc, Seq.empty)
+  extends RDD[T](sc, Seq.empty)
   with LazyLogging {
 
-  val uniqueKey = if (uKey.isDefined) uKey.get else SolrQuerySupport.getUniqueKey(zkHost, collection.split(",")(0))
+  val uniqueKey: String = if (uKey.isDefined) uKey.get else SolrQuerySupport.getUniqueKey(zkHost, collection.split(",")(0))
 
   protected def copy(
       requestHandler: Option[String] = requestHandler,
@@ -41,118 +35,7 @@ class SolrRDD(
       rows: Option[Int] = rows,
       splitField: Option[String] = splitField,
       splitsPerShard: Option[Int] = splitsPerShard,
-      solrQuery: Option[SolrQuery] = solrQuery): SolrRDD = {
-    new SolrRDD(zkHost, collection, sc, requestHandler, query, fields, rows, splitField, splitsPerShard, solrQuery)
-  }
-
-  /*
-  * Get an Iterator that uses the export handler in Solr
-  */
-  @throws(classOf[Exception])
-  private def getExportHandlerBasedIterator(shardUrl : String, query : SolrQuery) = {
-
-    // Direct the queries to each shard, so we don't want distributed
-    query.set("distrib", false)
-
-    val sorts = query.getSorts
-    val sortParam = query.get("sort")
-    if ((sorts == null || sorts.isEmpty) && (sortParam == null || sortParam.isEmpty)) {
-      val fields = query.getFields
-      if (fields != null) {
-        if (fields.contains("id")) {
-          query.addSort("id", SolrQuery.ORDER.asc)
-        } else {
-          val firstField = fields.split(",")(0)
-          query.addSort(firstField, SolrQuery.ORDER.asc)
-        }
-      } else {
-        query.addSort("id", SolrQuery.ORDER.asc)
-      }
-      logWarning(s"Added required sort clause: "+query.getSorts+
-        "; this is probably incorrect so you should provide your own sort criteria.")
-    }
-
-    new SolrStreamIterator(shardUrl, SolrSupport.getHttpSolrClient(shardUrl), query)
-  }
-
-  @DeveloperApi
-  override def compute(split: Partition, context: TaskContext): Iterator[SolrDocument] = {
-    split match {
-      case partition: CloudStreamPartition =>
-        logInfo(s"Using StreamingExpressionResultIterator to process streaming expression for ${partition}")
-        val resultsIterator = new StreamingExpressionResultIterator(partition.zkhost, partition.collection, partition.params)
-        JavaConverters.asScalaIteratorConverter(resultsIterator.iterator()).asScala
-      case partition: SolrRDDPartition =>
-
-        //TODO: Add backup mechanism to StreamingResultsIterator by being able to query any replica in case the main url goes down
-        val url = partition.preferredReplica.replicaUrl
-        val query = partition.query
-        logger.info("Using the shard url " + url + " for getting partition data for split: "+ split.index)
-        val solrRequestHandler = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)
-        query.setRequestHandler(solrRequestHandler)
-        val resultsIterator: ResultsIterator =
-          if (solrRequestHandler == "/export") {
-            logger.info("Using export handler to fetch documents from "+partition.preferredReplica+" for query: "+partition.query)
-            getExportHandlerBasedIterator(url, query)
-          } else {
-            logger.info("Using cursorMarks to fetch documents from "+partition.preferredReplica+" for query: "+partition.query)
-            new StreamingResultsIterator(
-              SolrSupport.getHttpSolrClient(url),
-              partition.query,
-              partition.cursorMark)
-          }
-        context.addTaskCompletionListener { (context) =>
-          logger.info(f"Fetched ${resultsIterator.getNumDocs} rows from shard $url for partition ${split.index}")
-        }
-        JavaConverters.asScalaIteratorConverter(resultsIterator.iterator()).asScala
-
-      case partition: AnyRef => throw new Exception("Unknown partition type '" + partition.getClass)
-    }
-  }
-
-  override protected def getPartitions: Array[Partition] = {
-    val query = if (solrQuery.isEmpty) buildQuery else solrQuery.get
-    val rq = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)
-    if (rq == QT_STREAM || rq == QT_SQL) {
-      logInfo(s"Using SolrCloud stream partitioning scheme to process request to ${rq} for collection ${collection}")
-      return Array(new CloudStreamPartition(0, zkHost, collection, query))
-    }
-
-    val shards = SolrSupport.buildShardList(zkHost, collection)
-    // Add defaults for shards. TODO: Move this for different implementations (Streaming)
-
-    if (rq != QT_EXPORT) {
-      logInfo(s"rq = $rq, setting query defaults for query = $query uniqueKey = $uniqueKey")
-      SolrQuerySupport.setQueryDefaultsForShards(query, uniqueKey)
-      // Freeze the index by adding a filter query on _version_ field
-      val max = SolrQuerySupport.getMaxVersion(SolrSupport.getCachedCloudClient(zkHost), collection, query, DEFAULT_SPLIT_FIELD)
-      if (max.isDefined) {
-        val rangeFilter = DEFAULT_SPLIT_FIELD + ":[* TO " + max.get + "]"
-        logInfo("Range filter added to the query: " + rangeFilter)
-        query.addFilterQuery(rangeFilter)
-      }
-    }
-
-    val numReplicas = shards.apply(0).replicas.length
-    val numSplits = splitsPerShard.getOrElse(2 * numReplicas)
-    logger.info(s"Using splitField=${splitField}, splitsPerShard=${splitsPerShard}, and numReplicas=${numReplicas} for computing partitions.")
-
-    val partitions : Array[Partition] = if (rq != QT_EXPORT && numSplits > 1) {
-      val splitFieldName = splitField.getOrElse(DEFAULT_SPLIT_FIELD)
-      logger.info(s"Applied ${numSplits} intra-shard splits on the ${splitFieldName} field for ${collection} to better utilize all active replicas. Set the 'split_field' option to override this behavior or set the 'splits_per_shard' option = 1 to disable splits per shard.")
-      SolrPartitioner.getSplitPartitions(shards, query, splitFieldName, numSplits)
-    } else {
-      // no explicit split field and only one replica || splits_per_shard was explicitly set to 1, no intra-shard splitting needed
-      SolrPartitioner.getShardPartitions(shards, query)
-    }
-
-    if (log.isDebugEnabled) {
-      logger.debug(s"Found ${partitions.length} partitions: ${partitions.mkString(",")}")
-    } else {
-      logger.info(s"Found ${partitions.length} partitions.")
-    }
-    partitions
-  }
+      solrQuery: Option[SolrQuery] = solrQuery)
 
   override def getPreferredLocations(split: Partition): Seq[String] = {
     val urls: Seq[String] = Seq.empty
@@ -164,38 +47,29 @@ class SolrRDD(
     urls
   }
 
-  private def getAllAddresses(hostName: String): Array[InetAddress] = {
-    try {
-      return InetAddress.getAllByName(hostName)
-    } catch {
-      case e: Exception => logger.info("Exception while resolving IP address for host name '" + hostName + "' with exception " + e)
-    }
-    Array.empty[InetAddress]
-  }
+  def query(q: String)
 
-  def query(q: String): SolrRDD = copy(query = Option(q))
+  def query(solrQuery: SolrQuery): this
 
-  def query(solrQuery: SolrQuery): SolrRDD = copy(solrQuery = Option(solrQuery))
+  def select(fl: String): Self = copy(fields = Some(fl.split(",")))
 
-  def select(fl: String): SolrRDD = copy(fields = Some(fl.split(",")))
+  def select(fl: Array[String]): Self = copy(fields = Some(fl))
 
-  def select(fl: Array[String]): SolrRDD = copy(fields = Some(fl))
+  def rows(rows: Int): Self = copy(rows = Some(rows))
 
-  def rows(rows: Int): SolrRDD = copy(rows = Some(rows))
+  def doSplits(): Self = copy(splitField = Some(DEFAULT_SPLIT_FIELD))
 
-  def doSplits(): SolrRDD = copy(splitField = Some(DEFAULT_SPLIT_FIELD))
+  def splitField(field: String): Self = copy(splitField = Some(field))
 
-  def splitField(field: String): SolrRDD = copy(splitField = Some(field))
+  def splitsPerShard(splitsPerShard: Int): Self = copy(splitsPerShard = Some(splitsPerShard))
 
-  def splitsPerShard(splitsPerShard: Int): SolrRDD = copy(splitsPerShard = Some(splitsPerShard))
+  def useExportHandler: Self = copy(requestHandler = Some(QT_EXPORT))
 
-  def useExportHandler: SolrRDD = copy(requestHandler = Some(QT_EXPORT))
-
-  def requestHandler(requestHandler: String): SolrRDD = copy(requestHandler = Some(requestHandler))
+  def requestHandler(requestHandler: String): Self = copy(requestHandler = Some(requestHandler))
 
   def solrCount: BigInt = SolrQuerySupport.getNumDocsFromSolr(collection, zkHost, solrQuery)
 
-  def buildQuery: SolrQuery = {
+  protected def buildQuery: SolrQuery = {
     var solrQuery : SolrQuery = SolrQuerySupport.toQuery(query.get)
     if (!solrQuery.getFields.eq(null) && solrQuery.getFields.length > 0) {
       solrQuery = solrQuery.setFields(fields.getOrElse(Array.empty[String]):_*)
@@ -220,8 +94,32 @@ object SolrRDD {
     solrShard.replicas(Random.nextInt(solrShard.replicas.size))
   }
 
-  def apply(zkHost: String, collection: String, sc: SparkContext) =
-    new SolrRDD(zkHost, collection, sc)
+  def apply(
+      zkHost: String,
+      collection: String,
+      @transient sc: SparkContext,
+      requestHandler: Option[String] = None,
+      query : Option[String] = Option(DEFAULT_QUERY),
+      fields: Option[Array[String]] = None,
+      rows: Option[Int] = Option(DEFAULT_PAGE_SIZE),
+      splitField: Option[String] = None,
+      splitsPerShard: Option[Int] = None,
+      solrQuery: Option[SolrQuery] = None,
+      uKey: Option[String] = None): SolrRDD[_] = {
+    if (requestHandler.isDefined) {
+      if (requiresStreamingRDD(requestHandler.get)) {
+        new StreamingSolrRDD(zkHost, collection, sc, requestHandler, query, fields, rows, splitField, splitsPerShard, solrQuery, uKey)
+      } else {
+        new SelectSolrRDD(zkHost, collection, sc, requestHandler, query, fields, rows, splitField, splitsPerShard, solrQuery, uKey)
+      }
+    } else {
+      new SelectSolrRDD(zkHost, collection, sc, Some(DEFAULT_REQUEST_HANDLER), query, fields, rows, splitField, splitsPerShard, solrQuery, uKey)
+    }
+  }
+
+  def requiresStreamingRDD(rq: String): Boolean = {
+    rq == QT_EXPORT || rq == QT_STREAM || rq == QT_SQL
+  }
 
 }
 

--- a/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
@@ -6,7 +6,6 @@ import com.lucidworks.spark.util.{SolrQuerySupport, SolrSupport}
 import com.lucidworks.spark.{CloudStreamPartition, SolrPartitioner, SolrRDDPartition}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.SolrQuery
-import org.apache.solr.client.solrj.io.Tuple
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 
@@ -24,7 +23,7 @@ class StreamingSolrRDD(
     splitsPerShard: Option[Int] = None,
     solrQuery: Option[SolrQuery] = None,
     uKey: Option[String] = None)
-  extends SolrRDD[Tuple](zkHost, collection, sc)
+  extends SolrRDD[java.util.Map[_, _]](zkHost, collection, sc)
   with LazyLogging {
 
   protected def copy(
@@ -70,7 +69,7 @@ class StreamingSolrRDD(
 
 
   @DeveloperApi
-  override def compute(split: Partition, context: TaskContext): Iterator[Tuple] = {
+  override def compute(split: Partition, context: TaskContext): Iterator[java.util.Map[_, _]] = {
     split match {
       case partition: CloudStreamPartition =>
         logger.info(s"Using StreamingExpressionResultIterator to process streaming expression for $partition")

--- a/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
@@ -1,0 +1,127 @@
+package com.lucidworks.spark.rdd
+
+import com.lucidworks.spark.query.{SolrStreamIterator, StreamingExpressionResultIterator}
+import com.lucidworks.spark.util.QueryConstants._
+import com.lucidworks.spark.util.SolrSupport
+import com.lucidworks.spark.{CloudStreamPartition, SolrPartitioner, SolrRDDPartition}
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.solr.client.solrj.SolrQuery
+import org.apache.solr.client.solrj.io.Tuple
+import org.apache.spark.annotation.DeveloperApi
+import org.apache.spark.{Partition, SparkContext, TaskContext}
+
+import scala.collection.JavaConverters
+
+class StreamingSolrRDD(
+    zkHost: String,
+    collection: String,
+    @transient sc: SparkContext,
+    requestHandler: Option[String] = None,
+    query : Option[String] = Option(DEFAULT_QUERY),
+    fields: Option[Array[String]] = None,
+    rows: Option[Int] = Option(DEFAULT_PAGE_SIZE),
+    splitField: Option[String] = None,
+    splitsPerShard: Option[Int] = None,
+    solrQuery: Option[SolrQuery] = None,
+    uKey: Option[String] = None)
+  extends SolrRDD[Tuple](zkHost, collection, sc)
+  with LazyLogging {
+
+  override type Self = StreamingSolrRDD
+
+  protected def copy(
+    requestHandler: Option[String] = requestHandler,
+    query: Option[String] = query,
+    fields: Option[Array[String]] = fields,
+    rows: Option[Int] = rows,
+    splitField: Option[String] = splitField,
+    splitsPerShard: Option[Int] = splitsPerShard,
+    solrQuery: Option[SolrQuery] = solrQuery): Self = {
+    new StreamingSolrRDD(zkHost, collection, sc, requestHandler, query, fields, rows, splitField, splitsPerShard, solrQuery, uKey)
+  }
+
+  /*
+   * Get an Iterator that uses the export handler in Solr
+   */
+  @throws(classOf[Exception])
+  private def getExportHandlerBasedIterator(shardUrl : String, query : SolrQuery) = {
+
+    // Direct the queries to each shard, so we don't want distributed
+    query.set("distrib", false)
+
+    val sorts = query.getSorts
+    val sortParam = query.get("sort")
+    if ((sorts == null || sorts.isEmpty) && (sortParam == null || sortParam.isEmpty)) {
+      val fields = query.getFields
+      if (fields != null) {
+        if (fields.contains("id")) {
+          query.addSort("id", SolrQuery.ORDER.asc)
+        } else {
+          val firstField = fields.split(",")(0)
+          query.addSort(firstField, SolrQuery.ORDER.asc)
+        }
+      } else {
+        query.addSort("id", SolrQuery.ORDER.asc)
+      }
+      logger.warn(s"Added required sort clause: "+query.getSorts+
+        "; this is probably incorrect so you should provide your own sort criteria.")
+    }
+
+    new SolrStreamIterator(shardUrl, SolrSupport.getHttpSolrClient(shardUrl), query)
+  }
+
+
+  @DeveloperApi
+  override def compute(split: Partition, context: TaskContext): Iterator[Tuple] = {
+    split match {
+      case partition: CloudStreamPartition =>
+        logger.info(s"Using StreamingExpressionResultIterator to process streaming expression for $partition")
+        val resultsIterator = new StreamingExpressionResultIterator(partition.zkhost, partition.collection, partition.params)
+        JavaConverters.asScalaIteratorConverter(resultsIterator.iterator()).asScala
+      case partition: SolrRDDPartition =>
+
+        //TODO: Add backup mechanism to StreamingResultsIterator by being able to query any replica in case the main url goes down
+        val url = partition.preferredReplica.replicaUrl
+        val query = partition.query
+        logger.info("Using the shard url " + url + " for getting partition data for split: "+ split.index)
+        val solrRequestHandler = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)
+        query.setRequestHandler(solrRequestHandler)
+        logger.info("Using export handler to fetch documents from " + partition.preferredReplica + " for query: "+partition.query)
+        val resultsIterator = getExportHandlerBasedIterator(url, query)
+        context.addTaskCompletionListener { (context) =>
+          logger.info(f"Fetched ${resultsIterator.getNumDocs} rows from shard $url for partition ${split.index}")
+        }
+        JavaConverters.asScalaIteratorConverter(resultsIterator.iterator()).asScala
+
+      case partition: AnyRef => throw new Exception("Unknown partition type '" + partition.getClass)
+    }
+  }
+
+  override def getPartitions: Array[Partition] = {
+    val query = if (solrQuery.isEmpty) buildQuery else solrQuery.get
+    val rq = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)
+    if (rq == QT_STREAM || rq == QT_SQL) {
+      logger.info(s"Using SolrCloud stream partitioning scheme to process request to $rq for collection $collection")
+      return Array(CloudStreamPartition(0, zkHost, collection, query))
+    }
+
+    val shards = SolrSupport.buildShardList(zkHost, collection)
+    val numReplicas = shards.head.replicas.length
+    val numSplits = splitsPerShard.getOrElse(2 * numReplicas)
+    logger.info(s"Using splitField=$splitField, splitsPerShard=$splitsPerShard, and numReplicas=$numReplicas for computing partitions.")
+
+    val partitions = SolrPartitioner.getShardPartitions(shards, query)
+    if (logger.underlying.isDebugEnabled) {
+      logger.debug(s"Found ${partitions.length} partitions: ${partitions.mkString(",")}")
+    } else {
+      logger.info(s"Found ${partitions.length} partitions.")
+    }
+    partitions
+  }
+}
+
+object StreamingSolrRDD {
+  def apply(zkHost: String, collection: String, sparkContext: SparkContext): StreamingSolrRDD = {
+    new StreamingSolrRDD(zkHost, collection, sparkContext)
+  }
+}

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -16,8 +16,6 @@ object ConfigurationConstants {
   val SKIP_NON_DOCVALUE_FIELDS: String = "skip_non_dv"
   val SOLR_DOC_VALUES: String = "dv"
   val FLATTEN_MULTIVALUED: String = "flatten_multivalued"
-  @deprecated
-  val USE_EXPORT_HANDLER: String = "use_export_handler"
   val REQUEST_HANDLER: String = "request_handler"
   val USE_CURSOR_MARKS: String = "use_cursor_marks"
   val SOLR_STREAMING_EXPR: String = "expr"

--- a/src/main/scala/com/lucidworks/spark/util/Constants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/Constants.scala
@@ -2,4 +2,5 @@ package com.lucidworks.spark.util
 
 object Constants {
   val SOLR_FORMAT = "solr"
+  val PROMOTE_TO_DOUBLE = "promote_to_double"
 }

--- a/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
@@ -646,7 +646,7 @@ object SolrQuerySupport extends LazyLogging {
   def withPivotFields(
       solrData: DataFrame,
       pivotFields: Array[PivotField],
-      solrRDD: SolrRDD,
+      solrRDD: SolrRDD[_],
       escapeFieldNames: Boolean): DataFrame = {
     val schema = SolrRelationUtil.getBaseSchema(solrRDD.zkHost, solrRDD.collection, escapeFieldNames, true, false)
     val schemaWithPivots = toPivotSchema(solrData.schema, pivotFields, solrRDD.collection, schema, solrRDD.uniqueKey, solrRDD.zkHost)

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -1,8 +1,10 @@
 package com.lucidworks.spark.util
 
 import java.sql.Timestamp
+import java.util
 import java.util.Date
 
+import com.lucidworks.spark.rdd.{SelectSolrRDD, StreamingSolrRDD}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.io.Tuple
@@ -301,91 +303,117 @@ object SolrRelationUtil extends LazyLogging {
 
   def toRows(schema: StructType, docs:RDD[_]): RDD[Row] = {
     docs match {
-      case streamingRDD: RDD[Tuple] =>  tupleToRows(schema, streamingRDD)
-      case selectRDD: RDD[SolrDocument] => solrDocToRows(schema, selectRDD)
+      case streamingRDD: StreamingSolrRDD =>  solrDocToRows[Tuple](schema, streamingRDD)
+      case selectRDD: SelectSolrRDD => solrDocToRows[SolrDocument](schema, selectRDD)
       case _ => throw new Exception("Unknown SolrRDD type")
     }
   }
 
-  def tupleToRows(schema: StructType, docs: RDD[Tuple]): RDD[Row] = ???
+  def processFieldValue(fieldValue: Object, fieldType: DataType, multiValued: Boolean): Any = {
+    fieldValue match {
+      case d: Date => new Timestamp(d.getTime)
+      case s: String =>
+        // This is a workaround. When date fields are streamed through export handler, they are represented with String class type
+        if (fieldType.eq(TimestampType)) new Timestamp(DateTime.parse(s).getMillis)
+        else s
+      case i: java.lang.Integer => new java.lang.Long(i.longValue())
+      case f: java.lang.Float => new java.lang.Double(f.doubleValue())
+      case al: java.util.ArrayList[_] =>
+        val jlist = al.iterator.map {
+          case d: Date => new Timestamp(d.getTime)
+          case s: String =>
+            fieldType match {
+              case at: ArrayType => if (at.elementType.eq(TimestampType)) new Timestamp(DateTime.parse(s).getMillis) else s
+              case _: TimestampType => new Timestamp(DateTime.parse(s).getMillis)
+              case _ => s
+            }
+          case i: java.lang.Integer => new java.lang.Long(i.longValue())
+          case f: java.lang.Float => new java.lang.Double(f.doubleValue())
+          case v => v
+        }
+        val jlistArray = jlist.toArray
+        if (multiValued)
+          jlistArray
+        else {
+          if (jlistArray.nonEmpty) jlistArray(0) else null
+        }
+      case it : Iterable[_] =>
+        val iterableValues = it.iterator.map {
+          case d: Date => new Timestamp(d.getTime)
+          case s: String =>
+            fieldType match {
+              case at: ArrayType => if (at.elementType.eq(TimestampType)) new Timestamp(DateTime.parse(s).getMillis) else s
+              case _: TimestampType => new Timestamp(DateTime.parse(s).getMillis)
+              case _ => s
+            }
+          case i: java.lang.Integer => new java.lang.Long(i.longValue())
+          case f: java.lang.Float => new java.lang.Double(f.doubleValue())
+          case v => v
+        }
+        val iterArray = iterableValues.toArray
+        if (multiValued)
+          iterArray
+        else {
+          if (iterArray.nonEmpty) iterArray(0) else null
+        }
+      case a => a
+    }
+  }
 
-  def solrDocToRows(schema: StructType, docs: RDD[SolrDocument]): RDD[Row] = {
+  def processMultipleFieldValues(fieldValues: util.Collection[Object], fieldType: DataType): Array[AnyRef] = {
+    if (fieldValues != null) {
+      val iterableValues = fieldValues.iterator().map {
+        case d: Date => new Timestamp(d.getTime)
+        case s: String =>
+          fieldType match {
+            // This is a workaround. When date fields are streamed through export handler, they are represented with String class type
+            case t: ArrayType =>
+              if (t.asInstanceOf[ArrayType].elementType.eq(TimestampType))
+                new Timestamp(DateTime.parse(s).getMillis)
+              else
+                s
+            case _ => s
+          }
+        case i: java.lang.Integer => new java.lang.Long(i.longValue())
+        case f: java.lang.Float => new java.lang.Double(f.doubleValue())
+        case a => a
+      }
+      iterableValues.toArray
+    } else {
+       null
+    }
+  }
+
+  def solrDocToRows[T](schema: StructType, docs: RDD[T]): RDD[Row] = {
     val fields = schema.fields
 
-    val rows = docs.map(solrDocument => {
-      val values = new ListBuffer[AnyRef]
+    val rows = docs.map(doc => {
+      val values = new ListBuffer[Any]
       for (field <- fields) {
         val metadata = field.metadata
         val fieldType = schema.get(schema.indexOf(field)).dataType
         val isMultiValued = if (metadata.contains("multiValued")) metadata.getBoolean("multiValued") else false
         if (isMultiValued) {
-          val fieldValues = solrDocument.getFieldValues(field.name)
-          if (fieldValues != null) {
-            val iterableValues = fieldValues.iterator().map {
-              case d: Date => new Timestamp(d.getTime)
-              case s: String =>
-                fieldType match {
-                  // This is a workaround. When date fields are streamed through export handler, they are represented with String class type
-                  case t: ArrayType =>
-                    if (t.asInstanceOf[ArrayType].elementType.eq(TimestampType))
-                      new Timestamp(DateTime.parse(s).getMillis)
-                    else
-                      s
-                  case _ => s
-                }
-              case i: java.lang.Integer => new java.lang.Long(i.longValue())
-              case f: java.lang.Float => new java.lang.Double(f.doubleValue())
-              case a => a
-            }
-            values.add(iterableValues.toArray)
-          } else {
-            values.add(null)
+           doc match {
+            case solrDocument: SolrDocument =>
+              val fieldValues = solrDocument.getFieldValues(field.name)
+              values.add(processMultipleFieldValues(fieldValues, fieldType))
+            case tuple: Tuple =>
+              val tupleValue = tuple.get(field.name)
+              val newValue = processFieldValue(tupleValue, fieldType, multiValued = true)
+              newValue match {
+                case arr: Array[_] => values.add(arr)
+                case any => values.add(Array(any))
+              }
           }
         } else {
-          val fieldValue = solrDocument.getFieldValue(field.name)
-          fieldValue match {
-            case d: Date => values.add(new Timestamp(d.getTime))
-            case s: String =>
-              // This is a workaround. When date fields are streamed through export handler, they are represented with String class type
-              if (fieldType.eq(TimestampType))
-                values.add(new Timestamp(DateTime.parse(s).getMillis))
-              else
-                values.add(s)
-            case i: java.lang.Integer => values.add(new java.lang.Long(i.longValue()))
-            case f: java.lang.Float => values.add(new java.lang.Double(f.doubleValue()))
-            case al: java.util.ArrayList[_] =>
-              val jlist = al.iterator.map {
-                case d: Date => new Timestamp(d.getTime)
-                case s: String =>
-                  if (fieldType.eq(TimestampType))
-                    new Timestamp(DateTime.parse(s).getMillis)
-                  else
-                    s
-                case i: java.lang.Integer => new java.lang.Long(i.longValue())
-                case f: java.lang.Float => new java.lang.Double(f.doubleValue())
-                case v: Any => v
-              }
-              val arr = jlist.toArray
-              if (arr.length >= 1) {
-                values.add(arr(0).asInstanceOf[AnyRef])
-              }
-            case it : Iterable[_] =>
-              val iterableValues = it.iterator.map {
-                case d: Date => new Timestamp(d.getTime)
-                case s: String =>
-                  if (fieldType.eq(TimestampType))
-                    new Timestamp(DateTime.parse(s).getMillis)
-                  else
-                    s
-                case i: java.lang.Integer => new java.lang.Long(i.longValue())
-                case f: java.lang.Float => new java.lang.Double(f.doubleValue())
-                case v: Any => v
-              }
-              val arr = iterableValues.toArray
-              if (!arr.isEmpty) {
-                values.add(arr(0).asInstanceOf[AnyRef])
-              }
-            case a => values.add(a)
+          doc match {
+            case solrDocument: SolrDocument =>
+              val fieldValue = solrDocument.getFieldValue(field.name)
+              values.add(processFieldValue(fieldValue, fieldType, multiValued = false))
+            case tuple: Tuple =>
+              val tupleValue = tuple.get(field.name)
+              values.add(processFieldValue(tupleValue, fieldType, multiValued = false))
           }
         }
       }

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -409,10 +409,26 @@ object SolrRelationUtil extends LazyLogging {
           doc match {
             case solrDocument: SolrDocument =>
               val fieldValue = solrDocument.getFieldValue(field.name)
-              values.add(processFieldValue(fieldValue, fieldType, multiValued = false))
+              val newValue = processFieldValue(fieldValue, fieldType, multiValued = false)
+              if (metadata.contains(Constants.PROMOTE_TO_DOUBLE) && metadata.getBoolean(Constants.PROMOTE_TO_DOUBLE)) {
+                newValue match {
+                  case n: java.lang.Number => values.add(n.doubleValue())
+                  case a => values.add(a)
+                }
+              } else {
+                values.add(newValue)
+              }
             case map: util.Map[_,_] =>
               val obj = map.get(field.name).asInstanceOf[Object]
-              values.add(processFieldValue(obj, fieldType, multiValued = false))
+              val newValue = processFieldValue(obj, fieldType, multiValued = false)
+              if (metadata.contains(Constants.PROMOTE_TO_DOUBLE) && metadata.getBoolean(Constants.PROMOTE_TO_DOUBLE)) {
+                newValue match {
+                  case n: java.lang.Number => values.add(n.doubleValue())
+                  case a => values.add(a)
+                }
+              } else {
+                values.add(newValue)
+              }
           }
         }
       }

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -5,6 +5,7 @@ import java.util.Date
 
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.SolrQuery
+import org.apache.solr.client.solrj.io.Tuple
 import org.apache.solr.common.SolrDocument
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Row
@@ -298,8 +299,17 @@ object SolrRelationUtil extends LazyLogging {
     solrQuery.setFields(fieldList.toList:_*)
   }
 
-  //TODO: Full on testing with schemaless, multi-valued arrays etc...
-  def toRows(schema: StructType, docs: RDD[SolrDocument]): RDD[Row] = {
+  def toRows(schema: StructType, docs:RDD[_]): RDD[Row] = {
+    docs match {
+      case streamingRDD: RDD[Tuple] =>  tupleToRows(schema, streamingRDD)
+      case selectRDD: RDD[SolrDocument] => solrDocToRows(schema, selectRDD)
+      case _ => throw new Exception("Unknown SolrRDD type")
+    }
+  }
+
+  def tupleToRows(schema: StructType, docs: RDD[Tuple]): RDD[Row] = ???
+
+  def solrDocToRows(schema: StructType, docs: RDD[SolrDocument]): RDD[Row] = {
     val fields = schema.fields
 
     val rows = docs.map(solrDocument => {

--- a/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
+++ b/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
@@ -18,6 +18,7 @@ import java.io.Serializable;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 

--- a/src/test/java/com/lucidworks/spark/SolrRDDTest.java
+++ b/src/test/java/com/lucidworks/spark/SolrRDDTest.java
@@ -1,9 +1,6 @@
 package com.lucidworks.spark;
 
 import com.lucidworks.spark.rdd.SolrJavaRDD;
-import com.lucidworks.spark.rdd.SolrRDD;
-import com.lucidworks.spark.util.ConfigurationConstants;
-import com.lucidworks.spark.util.QueryConstants;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.client.solrj.request.QueryRequest;
 import org.apache.solr.common.SolrDocument;
@@ -116,7 +113,7 @@ public class SolrRDDTest extends RDDProcessorTestBase {
         SolrJavaRDD solrRDD = SolrJavaRDD.get(zkHost, testCollection, jsc.sc());
         List<SolrDocument> docs = solrRDD.query(queryStr).collect();
 
-        assert docs.size() == 2;
+        assert(docs.size() == 2);
         assert docs.get(0).get("id").equals(testCollection + "-1");
       }
 

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -2,7 +2,7 @@ package com.lucidworks.spark
 
 import java.util.Collections
 
-import com.lucidworks.spark.rdd.SolrRDD
+import com.lucidworks.spark.rdd.SelectSolrRDD
 import com.lucidworks.spark.util.ConfigurationConstants._
 import com.lucidworks.spark.util.SolrRelationUtil
 import org.apache.solr.client.solrj.SolrQuery
@@ -14,7 +14,7 @@ import scala.collection.JavaConverters._
 class EventsimTestSuite extends EventsimBuilder {
 
   test("Simple Query using RDD") {
-    val solrRDD = new SolrRDD(zkHost, collectionName, sc)
+    val solrRDD = new SelectSolrRDD(zkHost, collectionName, sc)
       .query("*:*")
       .rows(10)
       .select(Array("id"))
@@ -23,12 +23,12 @@ class EventsimTestSuite extends EventsimBuilder {
   }
 
   test("Split partitions default") {
-    val solrRDD = new SolrRDD(zkHost, collectionName, sc).doSplits()
+    val solrRDD = new SelectSolrRDD(zkHost, collectionName, sc).doSplits()
     testCommons(solrRDD)
   }
 
   test("Split partitions by field name") {
-    val solrRDD = new SolrRDD(zkHost, collectionName, sc).splitField("id").splitsPerShard(2)
+    val solrRDD = new SelectSolrRDD(zkHost, collectionName, sc).splitField("id").splitsPerShard(2)
     testCommons(solrRDD)
   }
 
@@ -239,7 +239,7 @@ class EventsimTestSuite extends EventsimBuilder {
     df.select("artist").take(1) // This should use '/export' handler because we are only requesting the field 'artist'
   }
 
-  def testCommons(solrRDD: SolrRDD): Unit = {
+  def testCommons(solrRDD: SelectSolrRDD): Unit = {
     val sparkCount = solrRDD.count()
 
     // assert counts

--- a/src/test/scala/com/lucidworks/spark/RDDTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/RDDTestSuite.scala
@@ -1,7 +1,8 @@
 package com.lucidworks.spark
 
 import java.util.UUID
-import com.lucidworks.spark.rdd.SolrRDD
+
+import com.lucidworks.spark.rdd.{SelectSolrRDD, StreamingSolrRDD}
 import com.lucidworks.spark.util.ConfigurationConstants._
 import com.lucidworks.spark.util.QueryConstants._
 import com.lucidworks.spark.util.SolrCloudUtil
@@ -14,7 +15,8 @@ class RDDTestSuite extends TestSuiteBuilder with LazyLogging {
     val collectionName = "testSimpleQuery" + UUID.randomUUID().toString
     SolrCloudUtil.buildCollection(zkHost, collectionName, 3, 2, cloudClient, sc)
     try {
-      val newRDD = new SolrRDD(zkHost, collectionName, sc)
+      val newRDD = new SelectSolrRDD(zkHost, collectionName, sc)
+      val docs = newRDD.collect()
       assert(newRDD.count() === 3)
     } finally {
       SolrCloudUtil.deleteCollection(collectionName, cluster)
@@ -25,7 +27,7 @@ class RDDTestSuite extends TestSuiteBuilder with LazyLogging {
     val collectionName = "testRDDPartitions" + UUID.randomUUID().toString
     SolrCloudUtil.buildCollection(zkHost, collectionName, 2, 4, cloudClient, sc)
     try {
-      val newRDD = new SolrRDD(zkHost, collectionName, sc)
+      val newRDD = new SelectSolrRDD(zkHost, collectionName, sc)
       val partitions = newRDD.partitions
       assert(partitions.length == 8)
     } finally {
@@ -37,7 +39,7 @@ class RDDTestSuite extends TestSuiteBuilder with LazyLogging {
     val collectionName = "testSimpleQuery" + UUID.randomUUID().toString
     SolrCloudUtil.buildCollection(zkHost, collectionName, 3999, 2, cloudClient, sc)
     try {
-      val newRDD = new SolrRDD(zkHost, collectionName, sc, rows=Option(Integer.MAX_VALUE)).useExportHandler
+      val newRDD = new StreamingSolrRDD(zkHost, collectionName, sc, rows=Option(Integer.MAX_VALUE)).requestHandler(QT_EXPORT)
       val cnt = newRDD.count()
       print("\n********************** RDD COUNT IS = " + cnt + "\n\n")
       assert(cnt === 3999)
@@ -50,7 +52,7 @@ class RDDTestSuite extends TestSuiteBuilder with LazyLogging {
     val collectionName = "testRDDPartitions" + UUID.randomUUID().toString
     SolrCloudUtil.buildCollection(zkHost, collectionName, 1002, 14, cloudClient, sc)
     try {
-      val newRDD = new SolrRDD(zkHost, collectionName, sc, rows=Option(Integer.MAX_VALUE)).useExportHandler
+      val newRDD = new StreamingSolrRDD(zkHost, collectionName, sc, rows=Option(Integer.MAX_VALUE)).requestHandler(QT_EXPORT)
       val partitions = newRDD.partitions
       assert(partitions.length === 14)
     } finally {
@@ -74,8 +76,7 @@ class RDDTestSuite extends TestSuiteBuilder with LazyLogging {
     try {
       val solrQuery = new SolrQuery()
       solrQuery.set(SOLR_STREAMING_EXPR, expr)
-      val streamExprRDD = new SolrRDD(zkHost, collectionName, sc, Some(QT_STREAM))
-      assert(streamExprRDD.requestHandler.get == QT_STREAM)
+      val streamExprRDD = new StreamingSolrRDD(zkHost, collectionName, sc, Some(QT_STREAM))
       val results = streamExprRDD.query(solrQuery).collect()
       assert(results.size == numDocs)
     } finally {


### PR DESCRIPTION
* SolrRDD is an abstract parameterized class and SelectSolrRDD, StreamingSolrRDD extend SolrRDD
* StreamingSolrRDD should be used for `/export`, `/stream`, `/sql`
* SelectSolrRDD should be used for everything else
* Return RDD[Map] for streaming expressions
* Avoid conversion of Tuple to SolrDocument during the fetching in stages
* Handling SOLR-9732 at Row conversion time. [commit](https://github.com/lucidworks/spark-solr/pull/132/commits/8c62bd4d5a16640ed73612d776cc766d8f4b10e4)
* Breaking compatibility with SolrJavaRDD. `SolrJavaRDD.get()` returns `SelectSolrRDD`