### PR TITLE
Lazy initialize SolrRelation variables

### DIFF
--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -88,12 +88,12 @@ class SolrRelation(
   // we don't need the baseSchema for streaming expressions, so we wrap it in an optional
   var baseSchema : Option[StructType] = None
 
-  val uniqueKey: String = SolrQuerySupport.getUniqueKey(conf.getZkHost.get, collection.split(",")(0))
-  val initialQuery: SolrQuery = buildQuery
+  lazy val uniqueKey: String = SolrQuerySupport.getUniqueKey(conf.getZkHost.get, collection.split(",")(0))
+  lazy val initialQuery: SolrQuery = buildQuery
   // Preserve the initial filters if any present in arbitrary config
-  var queryFilters: Array[String] = if (initialQuery.getFilterQueries != null) initialQuery.getFilterQueries else Array.empty[String]
+  lazy val queryFilters: Array[String] = if (initialQuery.getFilterQueries != null) initialQuery.getFilterQueries else Array.empty[String]
 
-  val querySchema: StructType = {
+  lazy val querySchema: StructType = {
     if (dataFrame.isDefined) {
       dataFrame.get.schema
     } else {

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -214,6 +214,7 @@ class EventsimTestSuite extends EventsimBuilder {
       SOLR_COLLECTION_PARAM -> collectionName
     )
     val solrRelation = new SolrRelation(options, None, sparkSession)
+    solrRelation.querySchema // Invoking querySchema builds the baseSchema
     val querySchema = SolrRelationUtil.deriveQuerySchema(Array("userId", "status", "artist", "song", "length"), solrRelation.baseSchema.get)
     val areFieldsDocValues = SolrRelation.checkQueryFieldsForDV(querySchema)
     assert(areFieldsDocValues)

--- a/src/test/scala/com/lucidworks/spark/TestSolrRelation.scala
+++ b/src/test/scala/com/lucidworks/spark/TestSolrRelation.scala
@@ -1,0 +1,22 @@
+package com.lucidworks.spark
+
+class TestSolrRelation extends SparkSolrFunSuite with SparkSolrContextBuilder {
+
+  test("empty solr relation") {
+    intercept[IllegalArgumentException] {
+      new SolrRelation(Map.empty, None, sparkSession)
+    }
+  }
+
+  test("Missing collection property") {
+    intercept[IllegalArgumentException] {
+      new SolrRelation(Map("zkhost" -> "localhost:121"), None, sparkSession)
+    }
+  }
+
+  test("relation object creation") {
+    val options = Map("zkhost" -> "dummy:9983", "collection" -> "test")
+    val relation = new SolrRelation(options, None, sparkSession)
+    assert(relation != null)
+  }
+}


### PR DESCRIPTION
* This should make the class unit testable without requiring a running Solr