### PR TITLE
Fix projection of push-down fields if supplied for streaming expr

### DIFF
--- a/src/main/java/com/lucidworks/spark/fusion/FusionPipelineClient.java
+++ b/src/main/java/com/lucidworks/spark/fusion/FusionPipelineClient.java
@@ -345,8 +345,10 @@ public class FusionPipelineClient {
       // ensure last request within the session timeout period, else reset the session
       long currTime = System.nanoTime();
       if (fusionSession == null || (currTime - fusionSession.sessionEstablishedAt) > maxNanosOfInactivity) {
-        log.info("Fusion session is likely expired (or soon will be) for " + url + ", " +
-                "pre-emptively re-setting this session before processing request " + requestId);
+        if (log.isDebugEnabled()) {
+          log.debug("Fusion session is likely expired (or soon will be) for " + url + ", " +
+              "pre-emptively re-setting this session before processing request " + requestId);
+        }
         fusionSession = resetSession(sessionKey);
         if (fusionSession == null)
           throw new IllegalStateException("Failed to re-connect to " + url +

--- a/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
@@ -98,7 +98,7 @@ class StreamingSolrRDD(
     val query = if (solrQuery.isEmpty) buildQuery else solrQuery.get
     val rq = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)
     if (rq == QT_STREAM || rq == QT_SQL) {
-      logger.info(s"Using SolrCloud stream partitioning scheme to process request to $rq for collection $collection")
+      logger.info(s"Using SolrCloud stream partitioning scheme to process request to $rq for collection $collection using query: $query")
       return Array(CloudStreamPartition(0, zkHost, collection, query))
     }
 


### PR DESCRIPTION
Make sure the schema used for building rows from a streaming expression matches the projected fields passed into buildScan