### PR TITLE
Support config options for basic auth and kerberos

### DIFF
--- a/src/main/scala/com/lucidworks/spark/rdd/SelectSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SelectSolrRDD.scala
@@ -52,7 +52,7 @@ class SelectSolrRDD(
         val solrRequestHandler = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)
         query.setRequestHandler(solrRequestHandler)
         logger.info("Using cursorMarks to fetch documents from " + partition.preferredReplica + " for query: " + partition.query)
-        val resultsIterator = new StreamingResultsIterator(SolrSupport.getHttpSolrClient(url), partition.query, partition.cursorMark)
+        val resultsIterator = new StreamingResultsIterator(SolrSupport.getHttpSolrClient(url, zkHost), partition.query, partition.cursorMark)
         context.addTaskCompletionListener { (context) =>
           logger.info(f"Fetched ${resultsIterator.getNumDocs} rows from shard $url for partition ${split.index}")
         }

--- a/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
@@ -64,7 +64,7 @@ class StreamingSolrRDD(
         "; this is probably incorrect so you should provide your own sort criteria.")
     }
 
-    new SolrStreamIterator(shardUrl, SolrSupport.getHttpSolrClient(shardUrl), query, numWorkers, workerId)
+    new SolrStreamIterator(shardUrl, SolrSupport.getHttpSolrClient(shardUrl, zkHost), query, numWorkers, workerId)
   }
 
 


### PR DESCRIPTION
* Support system params for defining config files for basic auth and kerberos
* Configs are `kerberos.config`, `basicauth.config`
* When these params are defined, the files defined in the configs are loaded using `SparkFiles` and then the appropriate system param is defined with the absolute path
