### PR TITLE
DataFrame reader/writer implicits,

### DIFF
--- a/src/main/scala/com/lucidworks/spark/util/SolrDataFrameImplicits.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrDataFrameImplicits.scala
@@ -5,7 +5,7 @@ import org.apache.spark.sql.{DataFrameReader, DataFrameWriter, Row, SaveMode}
 /**
   * Usage:
   *
-  * import DatasetLoader._
+  * import SolrDataFrameImplicits._
   * // then you can:
   * val spark: SparkSession
   * val collectionName: String
@@ -20,6 +20,8 @@ object SolrDataFrameImplicits {
   implicit class SolrReader(reader: DataFrameReader) {
     def solr(collection: String, query: String = "*:*") =
       reader.format("solr").option("collection", collection).option("query", query).load()
+    def solr(collection: String, options: Map[String, String]) =
+      reader.format("solr").option("collection", collection).options(options).load()
   }
 
   implicit class SolrWriter(writer: DataFrameWriter[Row]) {

--- a/src/main/scala/com/lucidworks/spark/util/SolrDataFrameImplicits.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrDataFrameImplicits.scala
@@ -1,0 +1,35 @@
+package com.lucidworks.spark.util
+
+import org.apache.spark.sql.{DataFrameReader, DataFrameWriter, Row, SaveMode}
+
+/**
+  * Usage:
+  *
+  * import DatasetLoader._
+  * // then you can:
+  * val spark: SparkSession
+  * val collectionName: String
+  * val df = spark.read.solr(collectionName)
+  * // do stuff
+  * df.write.solr(collectionName, overwrite = true)
+  * // or various other combinations, like setting your own options earlier
+  * df.write.option("zkhost", "some other solr cluster's zk host").solr(collectionName)
+  */
+object SolrDataFrameImplicits {
+
+  implicit class SolrReader(reader: DataFrameReader) {
+    def solr(collection: String, query: String = "*:*") =
+      reader.format("solr").option("collection", collection).option("query", query).load()
+  }
+
+  implicit class SolrWriter(writer: DataFrameWriter[Row]) {
+    def solr(collectionName: String, softCommitSecs: Int = 10, overwrite: Boolean = false, format: String = "solr") = {
+      writer
+        .format(format)
+        .option("collection", collectionName)
+        .option("soft_commit_secs", softCommitSecs.toString)
+        .mode(if(overwrite) SaveMode.Overwrite else SaveMode.Append)
+        .save()
+    }
+  }
+}

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -10,6 +10,7 @@ import org.apache.solr.client.solrj.SolrQuery.SortClause
 import org.apache.spark.sql.DataFrame
 
 import scala.collection.JavaConverters._
+import com.lucidworks.spark.util.SolrDataFrameImplicits._
 
 class EventsimTestSuite extends EventsimBuilder {
 
@@ -178,10 +179,7 @@ class EventsimTestSuite extends EventsimBuilder {
   }
 
   test("Length range filter queries") {
-    val df: DataFrame = sparkSession.read.format("solr")
-      .option("zkHost", zkHost)
-      .option("collection", collectionName)
-      .load()
+    val df: DataFrame = sparkSession.read.option("zkhost", zkHost).solr(collectionName)
     df.createOrReplaceTempView("events")
 
     val timeQueryDF = sparkSession.sql("SELECT * from events WHERE `length` >= '700' and `length` <= '1000'")

--- a/src/test/scala/com/lucidworks/spark/TestIndexing.scala
+++ b/src/test/scala/com/lucidworks/spark/TestIndexing.scala
@@ -3,6 +3,7 @@ package com.lucidworks.spark
 import java.util.UUID
 
 import com.lucidworks.spark.util.{ConfigurationConstants, SolrCloudUtil, SolrSupport}
+import com.lucidworks.spark.util.SolrDataFrameImplicits._
 
 class TestIndexing extends TestSuiteBuilder {
 
@@ -18,7 +19,7 @@ class TestIndexing extends TestSuiteBuilder {
       assert(csvDF.count() == 999)
 
       val solrOpts = Map("zkhost" -> zkHost, "collection" -> collectionName, ConfigurationConstants.GENERATE_UNIQUE_KEY -> "true")
-      csvDF.write.format("solr").options(solrOpts).mode(org.apache.spark.sql.SaveMode.Overwrite).save()
+      csvDF.write.option("zkhost", zkHost).option(ConfigurationConstants.GENERATE_UNIQUE_KEY, "true").solr(collectionName)
 
       // Explicit commit to make sure all docs are visible
       val solrCloudClient = SolrSupport.getCachedCloudClient(zkHost)


### PR DESCRIPTION
to add "df.write.solr(collection)" and "sparkSession.read.solr(collection, readQuery)" functionality