### PR TITLE
Replica fallback if the replica goes down during task compute

### DIFF
--- a/src/main/scala/com/lucidworks/spark/Partitioner.scala
+++ b/src/main/scala/com/lucidworks/spark/Partitioner.scala
@@ -15,7 +15,7 @@ object SolrPartitioner {
   def getShardPartitions(shards: List[SolrShard], query: SolrQuery) : Array[Partition] = {
     shards.zipWithIndex.map{ case (shard, i) =>
       // Chose any of the replicas as the active shard to query
-      ShardRDDPartition(i, "*", shard, query, SolrRDD.randomReplica(shard))}.toArray
+      SelectSolrRDDPartition(i, "*", shard, query, SolrRDD.randomReplica(shard))}.toArray
   }
 
   def getSplitPartitions(
@@ -23,12 +23,12 @@ object SolrPartitioner {
       query: SolrQuery,
       splitFieldName: String,
       splitsPerShard: Int): Array[Partition] = {
-    var splitPartitions = ArrayBuffer.empty[SplitRDDPartition]
+    var splitPartitions = ArrayBuffer.empty[SelectSolrRDDPartition]
     var counter = 0
     shards.foreach(shard => {
       val splits = SolrSupport.getShardSplits(query, shard, splitFieldName, splitsPerShard)
       splits.foreach(split => {
-        splitPartitions += SplitRDDPartition(counter, "*", shard, split.query, split.replica)
+        splitPartitions += SelectSolrRDDPartition(counter, "*", shard, split.query, split.replica)
         counter = counter + 1
       })
     })

--- a/src/main/scala/com/lucidworks/spark/SolrRDDPartition.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRDDPartition.scala
@@ -5,10 +5,9 @@ import org.apache.solr.common.params.SolrParams
 import org.apache.spark.Partition
 
 trait SolrRDDPartition extends Partition {
-  def cursorMark: String
-  def solrShard: SolrShard
-  def query: SolrQuery
-  def preferredReplica: SolrReplica // Preferred replica to query
+  val solrShard: SolrShard
+  val query: SolrQuery
+  var preferredReplica: SolrReplica // Preferred replica to query
 }
 
 case class CloudStreamPartition(
@@ -18,30 +17,22 @@ case class CloudStreamPartition(
     params: SolrParams)
   extends Partition
 
-case class ShardRDDPartition(
+case class SelectSolrRDDPartition(
     index: Int,
     cursorMark: String,
     solrShard: SolrShard,
     query: SolrQuery,
-    preferredReplica: SolrReplica)
-  extends SolrRDDPartition
-
-case class SplitRDDPartition(
-    index: Int,
-    cursorMark: String,
-    solrShard: SolrShard,
-    query: SolrQuery,
-    preferredReplica: SolrReplica)
+    var preferredReplica: SolrReplica)
   extends SolrRDDPartition
 
 case class ExportHandlerPartition(
     index: Int,
     solrShard: SolrShard,
     query: SolrQuery,
-    preferredReplica: SolrReplica,
+    var preferredReplica: SolrReplica,
     numWorkers: Int,
     workerId: Int)
-  extends Partition
+  extends SolrRDDPartition
 
 case class SolrLimitPartition(
     index: Int = 0,

--- a/src/main/scala/com/lucidworks/spark/rdd/SelectSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SelectSolrRDD.scala
@@ -1,9 +1,9 @@
 package com.lucidworks.spark.rdd
 
-import com.lucidworks.spark.{SolrLimitPartition, SolrPartitioner, SolrRDDPartition}
 import com.lucidworks.spark.query.StreamingResultsIterator
 import com.lucidworks.spark.util.QueryConstants._
 import com.lucidworks.spark.util.{SolrQuerySupport, SolrSupport}
+import com.lucidworks.spark.{SelectSolrRDDPartition, SolrLimitPartition, SolrPartitioner}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.common.SolrDocument
@@ -44,9 +44,8 @@ class SelectSolrRDD(
   @DeveloperApi
   override def compute(split: Partition, context: TaskContext): Iterator[SolrDocument] = {
     split match {
-      case partition: SolrRDDPartition => {
-        //TODO: Add backup mechanism to StreamingResultsIterator by being able to query any replica in case the main url goes down
-        val url = partition.preferredReplica.replicaUrl
+      case partition: SelectSolrRDDPartition => {
+        val url = getReplicaToQuery(partition, context.attemptNumber())
         val query = partition.query
         logger.debug(s"Using the shard url ${url} for getting partition data for split: ${split.index}")
         val solrRequestHandler = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -70,7 +70,12 @@ abstract class SolrRDD[T: ClassTag](
 
       // Query preferred replica to check if the response is successful. If not, try with a different replica
       try {
-        SolrQuerySupport.querySolr(SolrSupport.getCachedHttpSolrClient(preferredReplica, zkHost), partition.query, 0, "*")
+        partition match {
+          case _: SelectSolrRDDPartition =>
+            SolrQuerySupport.querySolr(SolrSupport.getCachedHttpSolrClient(preferredReplica, zkHost), partition.query.getCopy, 0, "*")
+          case _: ExportHandlerPartition =>
+            SolrQuerySupport.validateExportHandlerQuery(SolrSupport.getCachedHttpSolrClient(preferredReplica, zkHost), partition.query.getCopy)
+        }
         preferredReplica
       } catch {
         case e: Exception =>

--- a/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
@@ -82,7 +82,7 @@ class StreamingSolrRDD(
         JavaConverters.asScalaIteratorConverter(resultsIterator.iterator()).asScala
       case partition: ExportHandlerPartition =>
 
-        val url = getReplicaToQuery(partition, context.attemptNumber())
+        val url = partition.preferredReplica.replicaUrl
         val query = partition.query
         logger.debug(s"Using the shard url ${url} for getting partition data for split: ${split.index}")
         val solrRequestHandler = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)

--- a/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
@@ -82,7 +82,7 @@ class StreamingSolrRDD(
         JavaConverters.asScalaIteratorConverter(resultsIterator.iterator()).asScala
       case partition: ExportHandlerPartition =>
 
-        val url = partition.preferredReplica.replicaUrl
+        val url = getReplicaToQuery(partition, context.attemptNumber())
         val query = partition.query
         logger.debug(s"Using the shard url ${url} for getting partition data for split: ${split.index}")
         val solrRequestHandler = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)

--- a/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
@@ -84,10 +84,10 @@ class StreamingSolrRDD(
 
         val url = getReplicaToQuery(partition, context.attemptNumber())
         val query = partition.query
-        logger.info(s"Using the shard url ${url} for getting partition data for split: ${split.index}")
+        logger.debug(s"Using the shard url ${url} for getting partition data for split: ${split.index}")
         val solrRequestHandler = requestHandler.getOrElse(DEFAULT_REQUEST_HANDLER)
         query.setRequestHandler(solrRequestHandler)
-        logger.info(s"Using export handler to fetch documents from ${partition.preferredReplica} for query: ${partition.query}")
+        logger.debug(s"Using export handler to fetch documents from ${partition.preferredReplica} for query: ${partition.query}")
         val resultsIterator = getExportHandlerBasedIterator(url, query, partition.numWorkers, partition.workerId)
         context.addTaskCompletionListener { (context) =>
           logger.info(f"Fetched ${resultsIterator.getNumDocs} rows from shard $url for partition ${split.index}")

--- a/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
@@ -477,7 +477,7 @@ object SolrQuerySupport extends LazyLogging {
       }
     } catch {
       case e: Any =>
-        logger.error("Error while validating query request: " + queryRequest.toString)
+        logger.error("Error while validating query request: " + cloneQuery.toString)
         throw e
     }
   }

--- a/src/test/scala/com/lucidworks/spark/TestShardSplits.scala
+++ b/src/test/scala/com/lucidworks/spark/TestShardSplits.scala
@@ -45,7 +45,7 @@ class TestShardSplits extends SparkSolrFunSuite{
     assert(partitions.length == 4)
     partitions.zipWithIndex.foreach {
       case (partition, i) =>
-        val spartition = partition.asInstanceOf[SolrRDDPartition]
+        val spartition = partition.asInstanceOf[SelectSolrRDDPartition]
         assert(spartition.cursorMark == "*")
         assert(spartition.query.get("partitionKeys") == splitFieldName)
         assert(spartition.query.getFilterQueries.apply(0) == s"{!hash workers=2 worker=${i%2}}")


### PR DESCRIPTION
* Works only for `/select` handler
* When the task fails once, we check the health of the replica and switch to another replica if the preferredReplica can't be queried