### PR TITLE
Make spark get the right host&port without the tailing '_solr'.

### DIFF
--- a/src/main/scala/com/lucidworks/spark/Partitioner.scala
+++ b/src/main/scala/com/lucidworks/spark/Partitioner.scala
@@ -73,6 +73,7 @@ case class SolrReplica(
     replicaUrl: String,
     replicaHostName: String,
     locations: Array[InetAddress]) {
+  def getHostAndPort(): String = {replicaHostName.substring(0, replicaHostName.indexOf('_'))}
   override def toString(): String = {
     return s"SolrReplica(${replicaNumber}) ${replicaName}: url=${replicaUrl}, hostName=${replicaHostName}, locations="+locations.mkString(",")
   }

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -30,9 +30,9 @@ abstract class SolrRDD[T: ClassTag](
 
   override def getPreferredLocations(split: Partition): Seq[String] = {
     split match {
-      case partition: SplitRDDPartition => Array(partition.preferredReplica.replicaHostName)
-      case partition: SolrRDDPartition => Array(partition.preferredReplica.replicaHostName)
-      case partition: ExportHandlerPartition => Array(partition.preferredReplica.replicaHostName)
+      case partition: SplitRDDPartition => Array(partition.preferredReplica.getHostAndPort())
+      case partition: SolrRDDPartition => Array(partition.preferredReplica.getHostAndPort())
+      case partition: ExportHandlerPartition => Array(partition.preferredReplica.getHostAndPort())
       case _: AnyRef => Seq.empty
     }
   }


### PR DESCRIPTION
Current implementation will give `replicaHostName`, such as `idx5.oi.dev:8983_solr`, to the Spark. Which will cause the `parseInt` method in Spark YarnScheduer get the `java.lang.NumberFormatException`, since `8983_solr` is not integer. Bellow is a error log

```
17/06/21 12:40:53 INFO ContextLauncher: 17/06/21 12:40:53 ERROR scheduler.DAGSchedulerEventProcessLoop: DAGSchedulerEventProcessLoop failed; shutting down SparkContext
17/06/21 12:40:53 INFO ContextLauncher: java.lang.NumberFormatException: For input string: “8983_solr”
17/06/21 12:40:53 INFO ContextLauncher: 	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
17/06/21 12:40:53 INFO ContextLauncher: 	at java.lang.Integer.parseInt(Integer.java:580)
17/06/21 12:40:53 INFO ContextLauncher: 	at java.lang.Integer.parseInt(Integer.java:615)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.immutable.StringLike$class.toInt(StringLike.scala:272)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.immutable.StringOps.toInt(StringOps.scala:29)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.util.Utils$.parseHostPort(Utils.scala:959)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.cluster.YarnScheduler.getRackForHost(YarnScheduler.scala:36)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSetManager$$anonfun$org$apache$spark$scheduler$TaskSetManager$$addPendingTask$1.apply(TaskSetManager.scala:200)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSetManager$$anonfun$org$apache$spark$scheduler$TaskSetManager$$addPendingTask$1.apply(TaskSetManager.scala:181)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.mutable.ResizableArray$class.foreach(ResizableArray.scala:59)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.mutable.ArrayBuffer.foreach(ArrayBuffer.scala:48)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSetManager.org$apache$spark$scheduler$TaskSetManager$$addPendingTask(TaskSetManager.scala:181)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSetManager$$anonfun$1.apply$mcVI$sp(TaskSetManager.scala:160)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:160)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSetManager.<init>(TaskSetManager.scala:159)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSchedulerImpl.createTaskSetManager(TaskSchedulerImpl.scala:212)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.TaskSchedulerImpl.submitTasks(TaskSchedulerImpl.scala:176)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler.submitMissingTasks(DAGScheduler.scala:1043)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$submitStage(DAGScheduler.scala:918)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler$$anonfun$org$apache$spark$scheduler$DAGScheduler$$submitStage$4.apply(DAGScheduler.scala:921)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler$$anonfun$org$apache$spark$scheduler$DAGScheduler$$submitStage$4.apply(DAGScheduler.scala:920)
17/06/21 12:40:53 INFO ContextLauncher: 	at scala.collection.immutable.List.foreach(List.scala:381)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler.org$apache$spark$scheduler$DAGScheduler$$submitStage(DAGScheduler.scala:920)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGScheduler.handleJobSubmitted(DAGScheduler.scala:862)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.doOnReceive(DAGScheduler.scala:1613)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1605)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.scheduler.DAGSchedulerEventProcessLoop.onReceive(DAGScheduler.scala:1594)
17/06/21 12:40:53 INFO ContextLauncher: 	at org.apache.spark.util.EventLoop$$anon$1.run(EventLoop.scala:48)
```

This PR has been tested with Spark2.1.1.