### PR TITLE
Get luke fields response from all shards

### DIFF
--- a/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
@@ -7,7 +7,6 @@ import com.lucidworks.spark.{CloudStreamPartition, ExportHandlerPartition, SolrP
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.spark.annotation.DeveloperApi
-import org.apache.spark.util.TaskCompletionListener
 import org.apache.spark.{Partition, SparkContext, TaskContext}
 
 import scala.collection.JavaConverters
@@ -100,11 +99,6 @@ class StreamingSolrRDD(
     if (accumulator.isDefined) {
       iterator.setAccumulator(accumulator.get)
     }
-    context.addTaskCompletionListener(new TaskCompletionListener {
-      override def onTaskCompletion(context: TaskContext): Unit = {
-        logger.info("Task input metrics for records: {}", context.taskMetrics().inputMetrics.recordsRead)
-      }
-    })
     JavaConverters.asScalaIteratorConverter(iterator.iterator()).asScala
   }
 

--- a/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
@@ -8,7 +8,7 @@ import com.lucidworks.spark.rdd.SolrRDD
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.SolrRequest.METHOD
 import org.apache.solr.client.solrj._
-import org.apache.solr.client.solrj.impl.{CloudSolrClient, InputStreamResponseParser, StreamingBinaryResponseParser}
+import org.apache.solr.client.solrj.impl.{CloudSolrClient, HttpSolrClient, InputStreamResponseParser, StreamingBinaryResponseParser}
 import org.apache.solr.client.solrj.request.schema.SchemaRequest
 import org.apache.solr.client.solrj.request.schema.SchemaRequest.UniqueKey
 import org.apache.solr.client.solrj.request.{LukeRequest, QueryRequest}
@@ -452,10 +452,20 @@ object SolrQuerySupport extends LazyLogging {
   }
 
   def getFieldsFromLuke(zkHost: String, collection: String): Set[String] = {
-    val cloudClient = SolrSupport.getCachedCloudClient(zkHost)
+    val shardList = SolrSupport.buildShardList(zkHost, collection)
+    val fieldSetBuffer: ListBuffer[String] = ListBuffer.empty[String]
+    shardList.foreach(shard => {
+      val randomReplica = SolrRDD.randomReplica(shard)
+      val replicaHttpClient = SolrSupport.getCachedHttpSolrClient(randomReplica.replicaUrl, zkHost)
+      fieldSetBuffer.++=(getFieldsFromLukePerShard(zkHost, replicaHttpClient))
+    })
+    fieldSetBuffer.toSet
+  }
+
+  def getFieldsFromLukePerShard(zkHost: String, httpSolrClient: HttpSolrClient): Set[String] = {
     val lukeRequest = new LukeRequest()
     lukeRequest.setNumTerms(0)
-    val lukeResponse = lukeRequest.process(cloudClient, collection)
+    val lukeResponse = lukeRequest.process(httpSolrClient)
     if (lukeResponse.getStatus != 0) {
       throw new RuntimeException(
         "Solr request returned with status code '" + lukeResponse.getStatus + "'. Response: '" + lukeResponse.getResponse.toString)

--- a/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
@@ -607,7 +607,6 @@ object SolrSupport extends LazyLogging {
                 case e : Exception => logger.warn("Error resolving ip address " + replicaCoreProps.getNodeName + " . Exception " + e)
                   replicas += SolrReplica(0, replicaCoreProps.getCoreName, replicaCoreProps.getCoreUrl, replicaCoreProps.getNodeName, Array.empty[InetAddress])
               }
-
             }
 
           }

--- a/src/test/scala/com/lucidworks/spark/RelationTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/RelationTestSuite.scala
@@ -506,21 +506,34 @@ class RelationTestSuite extends TestSuiteBuilder with LazyLogging {
 
       val opts = Map("zkhost" -> zkHost, "collection" -> collection)
 
-      // Hard to properly verify this but by sticking to one document, it is highly likely that this
-      // test will fail (2 out of 10 times) without the luke fetching data from each shard
-      var docs = Array(Array("1", true))
+      // Index docs using composite id's
+      var docs = Array(Array("1", true), Array("2", false), Array("3", true), Array("4", false))
       val updateRequest = new UpdateRequest()
-      docs.zipWithIndex.foreach{case(row, i) =>
+      docs.foreach(row => {
         val doc = new SolrInputDocument()
-        doc.setField("id", row(0))
+        doc.setField("id", "app1!" + row(0))
         doc.setField("stock_b", row(1))
         updateRequest.add(doc)
-      }
+      })
       updateRequest.process(cloudClient, collection)
       updateRequest.commit(cloudClient, collection)
 
+      docs = Array(Array("12", true), Array("22", false), Array("33", true), Array("44", false))
+      val updateRequest2 = new UpdateRequest()
+      docs.foreach(row => {
+        val doc = new SolrInputDocument()
+        doc.setField("id", "app2!" + row(0))
+        doc.setField("stock1_b", row(1))
+        updateRequest2.add(doc)
+      })
+      updateRequest2.process(cloudClient, collection)
+      updateRequest2.commit(cloudClient, collection)
+
+      // Validate the schema
       val df = sparkSession.read.format("solr").options(opts).load()
-      assert(df.count() == 1)
+      assert(df.schema.fieldNames.contains("stock_b"))
+      assert(df.schema.fieldNames.contains("stock1_b"))
+      assert(df.count() == 8)
     } finally {
       SolrCloudUtil.deleteCollection(collection, cluster)
     }

--- a/src/test/scala/com/lucidworks/spark/RelationTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/RelationTestSuite.scala
@@ -3,7 +3,7 @@ package com.lucidworks.spark
 import java.util.UUID
 
 import com.lucidworks.spark.util.ConfigurationConstants._
-import com.lucidworks.spark.util.{SolrCloudUtil, SolrQuerySupport}
+import com.lucidworks.spark.util.{SolrCloudUtil, SolrQuerySupport, SolrSupport}
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.request.{CollectionAdminRequest, UpdateRequest}
 import org.apache.solr.common.SolrInputDocument
@@ -496,6 +496,55 @@ class RelationTestSuite extends TestSuiteBuilder with LazyLogging {
       assert(rs.count == 1)
       rs = sparkSession.sql(s"select movie_id, title from ${moviesCollection} where title like '%Short'")
       assert(rs.count == 1)
+    }
+  }
+
+  test("Test cloud-aware luke") {
+    val collection = "testLukeCloudAware" + UUID.randomUUID().toString.replace("-", "_")
+    try {
+      SolrCloudUtil.buildCollection(zkHost, collection, null, 2, cloudClient, sc)
+      val shardList = SolrSupport.buildShardList(zkHost, collection)
+      val shard1Url = shardList.head.replicas.head.replicaUrl
+      val shard2Url = shardList(1).replicas.head.replicaUrl
+      val shard1HttpClient = SolrSupport.getCachedHttpSolrClient(shard1Url, zkHost)
+      val shard2HttpClient = SolrSupport.getCachedHttpSolrClient(shard2Url, zkHost)
+
+      val opts = Map("zkhost" -> zkHost, "collection" -> collection)
+
+      // Index docs separately to individual shards with different field names
+      var docs = Array(Array("1", true), Array("2", false), Array("3", true), Array("4", false))
+      val updateRequest = new UpdateRequest()
+      docs.foreach(row => {
+        val doc = new SolrInputDocument()
+        doc.setField("id", row(0))
+        doc.setField("stock_b", row(1))
+        updateRequest.add(doc)
+      })
+      updateRequest.process(shard1HttpClient)
+      updateRequest.commit(cloudClient, collection)
+
+      docs = Array(Array("12", true), Array("22", false), Array("33", true), Array("44", false))
+      val updateRequest2 = new UpdateRequest()
+      docs.foreach(row => {
+        val doc = new SolrInputDocument()
+        doc.setField("id", row(0))
+        doc.setField("stock1_b", row(1))
+        updateRequest2.add(doc)
+      })
+      updateRequest2.process(shard2HttpClient)
+      updateRequest2.commit(cloudClient, collection)
+
+      val df = sparkSession.read.format("solr").options(opts).load()
+      assert(df.count() == 8)
+
+      val df1 = sparkSession.read.format("solr").options(opts).option("solr.params", "fq=id:[* TO *]&fq=stock_b:true").load
+      assert(df1.count() == 2)
+
+      val df2 = sparkSession.read.format("solr").options(opts).option("solr.params", "fq=id:[* TO *]&fq=stock1_b:true").load
+      assert(df2.count() == 2)
+
+    } finally {
+      SolrCloudUtil.deleteCollection(collection, cluster)
     }
   }
 


### PR DESCRIPTION
* Luke handler in SolrCloud is not cloud aware
* Hence, we have to request data from each shard and combine it all. Otherwise, the code will fail if docs are not evenly distributed between shards
* Wrote a test that would fail (2 out of 10 times without the fix)
