### PR TITLE
Multiple range queries timestamp

### DIFF
--- a/src/main/scala/com/lucidworks/spark/TimePartitioningQuery.scala
+++ b/src/main/scala/com/lucidworks/spark/TimePartitioningQuery.scala
@@ -85,6 +85,8 @@ class TimePartitioningQuery(solrConf: SolrConf, query: SolrQuery) extends LazyLo
   }
 
   def getCollectionsForRangeQueries(rangeQueries: Array[String], partitions: List[String]): List[String] = {
+    if (rangeQueries.length > 2)
+      throw new IllegalArgumentException("Please consolidate date range filter criteria to at most 2 clauses!")
     if (rangeQueries.length == 2) {
       val query1Slice = getCollectionsForRangeQuery(rangeQueries(0), partitions)
       val query2Slice = getCollectionsForRangeQuery(rangeQueries(1), partitions)

--- a/src/main/scala/com/lucidworks/spark/TimePartitioningQuery.scala
+++ b/src/main/scala/com/lucidworks/spark/TimePartitioningQuery.scala
@@ -49,7 +49,7 @@ class TimePartitioningQuery(solrConf: SolrConf, query: SolrQuery) extends LazyLo
       return allPartitions
     }
     logger.debug(s"All partitions returned for query are: ${allPartitions}")
-    getCollectionsForRangeQuery(rangeQuery(0), allPartitions)
+    getCollectionsForRangeQueries(rangeQuery, allPartitions)
   }
 
   def getPartitions(activeOnly: Boolean): List[String] = {
@@ -82,6 +82,15 @@ class TimePartitioningQuery(solrConf: SolrConf, query: SolrQuery) extends LazyLo
       }
     })
     partitionListBuffer.toList.sorted
+  }
+
+  def getCollectionsForRangeQueries(rangeQueries: Array[String], partitions: List[String]): List[String] = {
+    if (rangeQueries.length == 2) {
+      val query1Slice = getCollectionsForRangeQuery(rangeQueries(0), partitions)
+      val query2Slice = getCollectionsForRangeQuery(rangeQueries(1), partitions)
+      return query1Slice.intersect(query2Slice)
+    }
+    getCollectionsForRangeQuery(rangeQueries(0), partitions)
   }
 
   def getCollectionsForRangeQuery(rangeQuery: String, partitions: List[String]): List[String] = {

--- a/src/test/scala/com/lucidworks/spark/TestPartitionByTimeQuerySupport.scala
+++ b/src/test/scala/com/lucidworks/spark/TestPartitionByTimeQuerySupport.scala
@@ -62,6 +62,10 @@ class TestPartitionByTimeQuerySupport extends TestSuiteBuilder {
       solrDF = sparkSession.read.format("solr").options(solrOpts).load()
       assert(solrDF.count == 63)
 
+      // querying a range with multiple timestamps
+      solrOpts = Map("zkhost" -> zkHost, "collection" -> baseCollectionName,"partition_by" -> "time","time_period" -> "1MINUTES","filters" -> "timestamp_tdt:[2014-11-24T17:30:00Z TO *],timestamp_tdt:[* TO 2014-11-24T17:31:00Z]")
+      solrDF = sparkSession.read.format("solr").options(solrOpts).load()
+      assert(solrDF.count == 34)
 
     } finally {
       SolrCloudUtil.deleteCollection(collection1Name, cluster)
@@ -135,4 +139,29 @@ class TestPartitionByTimeQuerySupport extends TestSuiteBuilder {
     val selectedPartitions = timePartitioningQuery.getCollectionsForRangeQuery(rangeQuery, allPartitions)
     assert(selectedPartitions.toSet == Set("events_2017_09_01", "events_2017_09_03", "events_2017_09_05", "events_2017_09_07", "events_2017_09_09"))
   }
+
+  test("Test partition selection lower bound and upper bound") {
+    val rangeQuery1 = "timestamp:[* TO 2017-09-09T00:00:00.00Z}"
+    val rangeQuery2 = "timestamp:{2017-09-07T00:00:00.00Z TO *]"
+    val solrQuery = new SolrQuery()
+    solrQuery.addFilterQuery(rangeQuery1)
+    solrQuery.addFilterQuery(rangeQuery2)
+
+    val dfParams = Map(
+      PARTITION_BY -> "time",
+      TIMESTAMP_FIELD_NAME -> "timestamp",
+      TIME_PERIOD -> "1DAYS",
+      DATETIME_PATTERN -> "yyyy_MM_dd",
+      TIMEZONE_ID -> "UTC",
+      "collection" -> "events"
+    )
+    val solrConf = new SolrConf(dfParams)
+
+    val timePartitioningQuery = new TimePartitioningQuery(solrConf, solrQuery)
+    val allPartitions = List("events_2017_09_01", "events_2017_09_03", "events_2017_09_05", "events_2017_09_07",
+      "events_2017_09_09", "events_2017_09_10", "events_2017_09_11", "events_2017_09_13")
+    val selectedPartitions = timePartitioningQuery.getCollectionsForRangeQueries(Array(rangeQuery1, rangeQuery2), allPartitions)
+    assert(selectedPartitions.toSet == Set("events_2017_09_07", "events_2017_09_09"))
+  }
+
 }


### PR DESCRIPTION
* Optimize SQL timestamp queries like

```
select * from events where timestamp  > 2017-11-20 and timestamp < 2017-11-22
```
* Previously, the above query would return a list like [2017-11-20, 2017-11-21, 2017-11-22, 2017-11-23, 2017-11-24, ...]
* With this PR, the list will subset to [2017-11-20, 2017-11-21] 
