### PR TITLE
Enable Databricks Integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.1.0</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -347,6 +347,14 @@
                   <pattern>org.apache.commons.cli</pattern>
                   <shadedPattern>shaded.apache.commons.cli</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>com.typesafe.scalalogging</pattern>
+                  <shadedPattern>shaded.typesafe.scalalogging</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.http</pattern>
+                  <shadedPattern>shaded.apache.http</shadedPattern>
+		</relocation>
               </relocations>
             </configuration>
           </execution>


### PR DESCRIPTION
# Shade HTTP Client and Scala Logging
We attempted to integrate Solr into Spark on the Databricks environment.  This was complicated by a couple of library conflicts.  In particular, Scala Logging and the Apache HTTP Client had a different version.  Our workaround is a local, forked build of the project.  This PR attempts to merge our fork back into upstream.

# Errors
Here are a couple of errors we ran into - might be useful for others to find this.  First, we ran into the issue of not being able to resolve `org.restlet.jee:org.restlet:2.3.0, org.restlet.jee:org.restlet.ext.servlet:2.3.0`.

Databricks uses `/databricks/jars/spark--maven-trees--spark_2.2--com.typesafe.scala-logging--scala-logging-slf4j_2.11--com.typesafe.scala-logging__scala-logging-slf4j_2.11__2.1.2.jar` and the Solr package uses `com.typesafe.scala-logging:scala-logging_2.11:3.4.0`  Attempting to exclude that package, lead to the error of the file not existing:
```
17/11/28 21:07:13 ERROR Uncaught throwable from user code: java.lang.NoClassDefFoundError: com/typesafe/scalalogging/LazyLogging
```

# Background Links
 * https://github.com/lucidworks/spark-solr/issues/149
 * http://lucene.472066.n3.nabble.com/http-client-mismatch-td4227125.html
 * https://github.com/lucidworks/spark-solr/issues/75
 * https://github.com/akka/reactive-kafka/issues/99#issuecomment-190648854
 *  https://databricks.com/product/unified-analytics-platform
 * https://github.com/typesafehub/scala-logging/issues/68