### PR TITLE
Solr JSON facet support with Spark Dataframes

### DIFF
--- a/src/main/scala/com/lucidworks/spark/JsonFacetUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/JsonFacetUtil.scala
@@ -1,0 +1,132 @@
+package com.lucidworks.spark
+
+import com.typesafe.scalalogging.LazyLogging
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types.{DataType, DataTypes, StructField, StructType}
+import org.json4s.{JObject, JValue}
+
+import scala.collection.mutable.ArrayBuffer
+
+object JsonFacetUtil extends LazyLogging {
+
+  def parseFacetResponse(facets: JValue, spark: SparkSession): DataFrame = {
+    facets match {
+      case jo : JObject =>
+        val nestedFacetKeys = jo.values.filter(f => isNestedFacetBlock(f._2)).keySet
+        if (nestedFacetKeys.nonEmpty) {
+          if (nestedFacetKeys.size > 1) {
+            logger.info(s"Multiple nested level facets defined. Only using field ${nestedFacetKeys.head} to generate dataframe")
+          }
+          jo.values(nestedFacetKeys.head) match {
+            case fjo: Map[String, _] @unchecked =>
+              if (fjo.contains("buckets")) {
+                // process facet values into dataframe
+                fjo("buckets") match {
+                  case buckets: List[Map[String, _]] @unchecked =>
+                    val schema : StructType = StructType(formSchema(nestedFacetKeys.head, buckets.head, Array.empty[StructField]))
+                    val data = convertFacetBucketsToDataFrame(buckets, schema)
+                    val rows: RDD[Row] = spark.sparkContext.parallelize(data, 1)
+                    return spark.createDataFrame(rows, schema)
+                  case a: Any => logger.info(s"Unknown type ${a.getClass}")
+                }
+              }
+            case a: Any => logger.info(s"Unknown type ${a.getClass}")
+          }
+        } else {
+          // no nested fields, just parse the keys and values
+          val fields: ArrayBuffer[StructField] = ArrayBuffer.empty[StructField]
+          val row: ArrayBuffer[Any] = ArrayBuffer.empty
+          for ((k, v) <- jo.values) {
+            val dv = getDataTypeAndValue(v)
+            fields.+=(StructField(k, dv._1))
+            row.+=(dv._2)
+          }
+          val rddRow = spark.sparkContext.parallelize(Seq(Row.fromSeq(row)), 1)
+          return spark.createDataFrame(rddRow, StructType(fields))
+        }
+      case _ => //
+    }
+    spark.emptyDataFrame
+  }
+
+  private def getDataTypeAndValue(a: Any) : (DataType, Any) = {
+    a match {
+      case bd : BigDecimal =>
+        (DataTypes.DoubleType, bd.toDouble)
+      case bi: BigInt =>
+        (DataTypes.IntegerType, bi.toInt)
+      case jd : java.lang.Double =>
+        (DataTypes.DoubleType, jd.toDouble)
+      case s : String =>
+        (DataTypes.StringType, s)
+      case a: Any => throw new Exception(s"Non compatible type: ${a.getClass}")
+    }
+  }
+
+  private def isNestedFacetBlock(any: Any): Boolean = {
+    any match {
+      case m : Map[String, _] @unchecked =>
+        if (m.contains("buckets")) return true
+      case _ => //
+    }
+    false
+  }
+
+  private def formSchema(key: String, head: Map[String, _], schema: Array[StructField]) : Array[StructField] = {
+    val buffer = ArrayBuffer.empty[StructField]
+    buffer.++=(schema)
+    if (head.contains("val")) {
+      val dv = getDataTypeAndValue(head("val"))
+      buffer.+=(StructField(key, dv._1))
+    }
+    if (head.contains("count")) {
+      buffer.+=(StructField(s"${key}_count", DataTypes.LongType))
+    }
+    for ((k, v) <- head.filter(p => p._1 != "count" && p._1 != "val")) {
+      v match {
+        case jo : Map[String, _] @unchecked=>
+          if (jo.contains("buckets")) {
+            jo("buckets") match {
+              case ja: List[Map[String, _]] @unchecked => return formSchema(k, ja.head, buffer.toArray)
+            }
+          }
+        case _ => //
+      }
+    }
+    buffer.toArray
+  }
+
+  private def convertFacetBucketsToDataFrame(value: List[Map[String, _]], schema: StructType) : Array[Row] = {
+    convertFacetBucketsToDataFrame(value, ArrayBuffer.empty, Array.empty, schema)
+  }
+
+  private def convertFacetBucketsToDataFrame(value: List[Map[String, _]], rows: ArrayBuffer[Row], array: Array[Any], schema: StructType) : Array[Row] = {
+    for (bucket <- value) {
+      val buffer = ArrayBuffer.empty[Any]
+      buffer.++=(array)
+      if (bucket.contains("val")) {
+        val dv = getDataTypeAndValue(bucket("val"))
+        buffer.+=(dv._2)
+      }
+      if (bucket.contains("count")) {
+        buffer.+=(bucket("count").asInstanceOf[BigInt].toLong)
+      }
+      if (buffer.length == schema.fieldNames.length) {
+        val row = Row.fromSeq(buffer)
+        rows.+=(row)
+      }
+      for ((_, v) <- bucket.filter(p => p._1 != "count" && p._1 != "val")) {
+        v match {
+          case jo : Map[String, _] @unchecked =>
+            if (jo.contains("buckets")) {
+              jo("buckets") match {
+                case ja: List[Map[String, _]] @unchecked => convertFacetBucketsToDataFrame(ja, rows, buffer.toArray, schema)
+              }
+            }
+        }
+      }
+    }
+    rows.toArray
+  }
+}

--- a/src/test/scala/com/lucidworks/spark/TestFacetQuerying.scala
+++ b/src/test/scala/com/lucidworks/spark/TestFacetQuerying.scala
@@ -1,0 +1,94 @@
+package com.lucidworks.spark
+
+import com.lucidworks.spark.util.SolrQuerySupport
+import org.apache.spark.sql.{DataFrame, Row}
+
+class TestFacetQuerying extends MovielensBuilder {
+
+  test("JSON Facet terms") {
+    val facetQuery =
+      """
+        | {
+        |   aggr_genre: {
+        |     type: terms,
+        |     field: genre,
+        |     limit: 30,
+        |     refine: true
+        |   }
+        | }
+      """.stripMargin
+    val queryString = s"q=*:*&json.facet=${facetQuery}"
+    val dataFrame: DataFrame = SolrQuerySupport.getDataframeFromFacetQuery(SolrQuerySupport.toQuery(queryString), moviesColName, zkHost, sparkSession)
+    assert(dataFrame.schema.fieldNames.length === 2)
+    assert(dataFrame.schema.fieldNames.toSet === Set("aggr_genre", "aggr_genre_count"))
+
+    val rows = dataFrame.collect()
+    assert(rows(0) == Row("drama", 531))
+    assert(rows(rows.length - 1) == Row("fantasy", 1))
+
+//    dataFrame.printSchema()
+//    dataFrame.show(20)
+  }
+
+
+  test("JSON facet nested top 2") {
+    val facetQuery =
+      """
+        | {
+        |   aggr_rating: {
+        |     type: terms,
+        |     field: "rating",
+        |     limit: 30,
+        |     refine: true,
+        |     facet: {
+        |       top_movies: {
+        |         type: terms,
+        |         field: movie_id,
+        |         limit: 2
+        |       }
+        |     }
+        |   },
+        |   num_genres: "unique(genre)"
+        | }
+      """.stripMargin
+    val queryString = s"q=*:*&json.facet=${facetQuery}"
+    val dataFrame: DataFrame = SolrQuerySupport.getDataframeFromFacetQuery(SolrQuerySupport.toQuery(queryString), ratingsColName, zkHost, sparkSession)
+    assert(dataFrame.schema.fieldNames.length === 4)
+    assert(dataFrame.schema.fieldNames.toSet === Set("aggr_rating", "aggr_rating_count", "top_movies", "top_movies_count"))
+
+    val rows = dataFrame.collect()
+    assert(rows(0) == Row(4, 3383, "9", 23))
+    assert(rows(1) == Row(4, 3383, "237", 21))
+    assert(rows(2) == Row(3, 2742, "294", 20))
+    assert(rows(3) == Row(3, 2742, "405", 19))
+    assert(rows(4) == Row(5, 2124, "50", 40))
+    assert(rows(5) == Row(5, 2124, "56", 25))
+    assert(rows(6) == Row(2, 1149, "118", 12))
+    assert(rows(7) == Row(2, 1149, "678", 10))
+    assert(rows(8) == Row(1, 602, "21", 5))
+    assert(rows(9) == Row(1, 602, "225", 4))
+//    dataFrame.printSchema()
+//    dataFrame.show(20)
+  }
+
+  test("JSON facet aggrs") {
+    val facetQuery =
+      """
+        | {
+        |   "avg_rating" : "avg(rating)",
+        |   "num_users" : "unique(user_id)",
+        |   "no_of_movies_rated" : "unique(movie_id)",
+        |   "median_rating" : "percentile(rating, 50)"
+        | }
+      """.stripMargin
+    val queryString = s"q=*:*&json.facet=${facetQuery}"
+    val dataFrame: DataFrame = SolrQuerySupport.getDataframeFromFacetQuery(SolrQuerySupport.toQuery(queryString), ratingsColName, zkHost, sparkSession)
+
+    assert(dataFrame.schema.fieldNames.toSet === Set("count", "num_users", "avg_rating", "no_of_movies_rated", "median_rating"))
+    val data = dataFrame.collect()
+
+    assert(data(0) == Row(10000, 922, 4.0, 1238, 3.5278))
+    //    dataFrame.printSchema()
+//    dataFrame.show()
+  }
+}


### PR DESCRIPTION
#TL;DR
* Convert Json facets from Solr response in to a dataframe
* Support nested terms support

# Details
Example 1:  JSON facet request with terms
```scala
      """
        | {
        |   aggr_genre: {
        |     type: terms,
        |     field: genre,
        |     limit: 30,
        |     refine: true
        |   }
        | }
      """.stripMargin
```

Dataframe: 
```sql
+-----------+----------------+
| aggr_genre|aggr_genre_count|
+-----------+----------------+
|      drama|             531|
|     comedy|             426|
|     action|             251|
|      crime|              74|
|     horror|              62|
|  adventure|              60|
|documentary|              49|
|   children|              48|

```

Example2: JSON facet request nested
```scala
      """
        | {
        |   aggr_rating: {
        |     type: terms,
        |     field: "rating",
        |     limit: 30,
        |     refine: true,
        |     facet: {
        |       top_movies: {
        |         type: terms,
        |         field: movie_id,
        |         limit: 2
        |       }
        |     }
        |   },
        |   num_genres: "unique(genre)"
        | }
      """.stripMargin
```

Dataframe:
```sql
+-----------+-----------------+----------+----------------+
|aggr_rating|aggr_rating_count|top_movies|top_movies_count|
+-----------+-----------------+----------+----------------+
|          4|             3383|         9|              23|
|          4|             3383|       237|              21|
|          3|             2742|       294|              20|
|          3|             2742|       405|              19|
|          5|             2124|        50|              40|
|          5|             2124|        56|              25|
|          2|             1149|       118|              12|
|          2|             1149|       678|              10|
|          1|              602|        21|               5|
|          1|              602|       225|               4|
```

Example3: JSON facet request with aggrs

```scala
      """
        | {
        |   "avg_rating" : "avg(rating)",
        |   "num_users" : "unique(user_id)",
        |   "no_of_movies_rated" : "unique(movie_id)",
        |   "median_rating" : "percentile(rating, 50)"
        | }
      """.stripMargin

```

Dataframe:

```sql
+-----+---------+-------------+------------------+----------+
|count|num_users|median_rating|no_of_movies_rated|avg_rating|
+-----+---------+-------------+------------------+----------+
|10000|      922|          4.0|              1238|    3.5278|
+-----+---------+-------------+------------------+----------+
```