### PR TITLE
Spark upgrade to 2.3.1 and bug fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <spark.version>2.3.0</spark.version>
+    <spark.version>2.3.1</spark.version>
     <solr.version>7.3.1</solr.version>
     <fasterxml.version>2.4.0</fasterxml.version>
     <scala.version>2.11.8</scala.version>

--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -129,6 +129,8 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
     None
   }
 
+  def getSolrFieldTypes: Option[String] = config.get(SOLR_FIELD_TYPES)
+
   def getArbitrarySolrParams: ModifiableSolrParams = {
     val solrParams = new ModifiableSolrParams()
     if (config.contains(ARBITRARY_PARAMS_STRING) && config.get(ARBITRARY_PARAMS_STRING).isDefined) {
@@ -223,6 +225,8 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
       sb ++= s", ${SOLR_SQL_SCHEMA}=${getSolrSQLSchema.get}"
     }
 
+    sb ++= s", extraOptions=${getExtraOptions}"
+
     // time-based partitioning options
     if (partitionBy.isDefined) {
       sb ++= s", ${PARTITION_BY}=${partitionBy.get}"
@@ -260,7 +264,10 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
       sb ++= s", ${CHILD_DOC_FIELDNAME}=${getChildDocFieldName.get}"
     }
     if (getAccumulatorName.isDefined) {
-    sb ++= s", ${ACCUMULATOR_NAME}=${getAccumulatorName.get}"
+      sb ++= s", ${ACCUMULATOR_NAME}=${getAccumulatorName.get}"
+    }
+    if (getSolrFieldTypes.isDefined) {
+      sb ++= s", ${SOLR_FIELD_TYPES}=${getSolrFieldTypes.get}"
     }
     sb ++= ")"
     sb.toString

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -30,6 +30,7 @@ object ConfigurationConstants {
   val GENERATE_UNIQUE_CHILD_KEY: String = "gen_uniq_child_key"
   val COMMIT_WITHIN_MILLI_SECS: String = "commit_within"
   val CHILD_DOC_FIELDNAME: String = "child_doc_fieldname"
+  val SOLR_FIELD_TYPES: String = "solr_field_types"
 
   val SAMPLE_SEED: String = "sample_seed"
   val SAMPLE_PCT: String = "sample_pct"

--- a/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
+++ b/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
@@ -47,7 +47,12 @@ public class RDDProcessorTestBase extends TestSolrCloudClusterSupport implements
 
   @AfterClass
   public static void stopSparkSession() {
-    sparkSession.stop();
+    try {
+      sparkSession.stop();
+    } finally {
+      SparkSession.clearActiveSession();
+      SparkSession.clearDefaultSession();
+    }
   }
 
   protected void buildCollection(String zkHost, String collection) throws Exception {

--- a/src/test/resources/test-data/simple.csv
+++ b/src/test/resources/test-data/simple.csv
@@ -1,4 +1,4 @@
-id,one_txt,two_txt,three_s
-1,A,B,C
-2,C,D,E
-3,F,G,H
+id,nrating,ntitle
+1,5,One Piece
+2,6,Hunter x Hunter
+3,4,Attack on Titan

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -252,7 +252,7 @@ class EventsimTestSuite extends EventsimBuilder {
         |       )
       """.stripMargin
     val queryResults = sparkSession.sql(sqlQuery).collectAsList()
-    assert(queryResults.size == 3)
+    assert(queryResults.size == 4)
   }
 
   // Ignored since Spark is not passing timestamps filters to the buildScan method. Range timestamp filtering is being done at Spark layer

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -217,6 +217,44 @@ class EventsimTestSuite extends EventsimBuilder {
     assert(timeQueryDF.count() == 987)
   }
 
+  test("Nested SQL Filter queries with OR/AND") {
+    val df: DataFrame = sparkSession.read.option("zkhost", zkHost).solr(collectionName)
+    df.createOrReplaceTempView("events")
+
+    val sqlQuery =
+      """
+        | SELECT userId, sessionId, page, lastName, firstName, method, level, gender, artist
+        |   FROM events
+        | WHERE page IN ('NextSong')
+        |       AND (
+        |         (gender = 'F' AND artist = 'Bernadette Peters')
+        |         OR
+        |         (gender = 'M' AND artist = 'Girl Talk')
+        |       )
+      """.stripMargin
+    val queryResults = sparkSession.sql(sqlQuery).collectAsList()
+    assert(queryResults.size == 3)
+  }
+
+  test("Nested SQL Filter queries with And/OR") {
+    val df: DataFrame = sparkSession.read.option("zkhost", zkHost).solr(collectionName)
+    df.createOrReplaceTempView("events")
+
+    val sqlQuery =
+      """
+        | SELECT userId, sessionId, page, lastName, firstName, method, level, gender, artist
+        |   FROM events
+        | WHERE page IN ('NextSong')
+        |       AND (
+        |         (method = 'PUT' OR method = 'GET')
+        |         AND
+        |         (artist = 'Gorillaz' OR artist = 'Girl Talk')
+        |       )
+      """.stripMargin
+    val queryResults = sparkSession.sql(sqlQuery).collectAsList()
+    assert(queryResults.size == 3)
+  }
+
   // Ignored since Spark is not passing timestamps filters to the buildScan method. Range timestamp filtering is being done at Spark layer
   ignore("Timestamp range filter queries") {
     val df: DataFrame = sparkSession.read.format("solr")

--- a/src/test/scala/com/lucidworks/spark/TestFramework.scala
+++ b/src/test/scala/com/lucidworks/spark/TestFramework.scala
@@ -84,7 +84,12 @@ trait SparkSolrContextBuilder extends BeforeAndAfterAll { this: Suite =>
   }
 
   override def afterAll(): Unit = {
-    sparkSession.stop()
+    try {
+      sparkSession.stop()
+    } finally {
+      SparkSession.clearDefaultSession()
+      SparkSession.clearActiveSession()
+    }
     super.afterAll()
   }
 }

--- a/src/test/scala/com/lucidworks/spark/TestIndexing.scala
+++ b/src/test/scala/com/lucidworks/spark/TestIndexing.scala
@@ -3,7 +3,7 @@ package com.lucidworks.spark
 import java.util.UUID
 
 import com.lucidworks.spark.util.SolrDataFrameImplicits._
-import com.lucidworks.spark.util.{ConfigurationConstants, SolrCloudUtil, SolrSupport}
+import com.lucidworks.spark.util.{ConfigurationConstants, SolrCloudUtil, SolrQuerySupport, SolrSupport}
 import org.apache.spark.sql.functions.{concat, lit}
 
 class TestIndexing extends TestSuiteBuilder {
@@ -19,7 +19,7 @@ class TestIndexing extends TestSuiteBuilder {
         .load(csvFileLocation)
       assert(csvDF.count() == 999)
 
-      val solrOpts = Map("zkhost" -> zkHost, "collection" -> collectionName, ConfigurationConstants.GENERATE_UNIQUE_KEY -> "true")
+      val solrOpts = Map("zkhost" -> zkHost, "collection" -> collectionName)
       val newDF = csvDF
         .withColumn("pickup_location", concat(csvDF.col("pickup_latitude"), lit(","), csvDF.col("pickup_longitude")))
         .withColumn("dropoff_location", concat(csvDF.col("dropoff_latitude"), lit(","), csvDF.col("dropoff_longitude")))
@@ -38,4 +38,30 @@ class TestIndexing extends TestSuiteBuilder {
     }
   }
 
+  test("Solr field types config") {
+    val collectionName = "testIndexing-" + UUID.randomUUID().toString
+    SolrCloudUtil.buildCollection(zkHost, collectionName, null, 2, cloudClient, sc)
+    try {
+      val csvFileLocation = "src/test/resources/test-data/simple.csv"
+      val csvDF = sparkSession.read.format("com.databricks.spark.csv")
+          .option("header", "true")
+          .option("inferSchema", "true")
+          .load(csvFileLocation)
+      val solrOpts = Map("zkhost" -> zkHost, "collection" -> collectionName, ConfigurationConstants.SOLR_FIELD_TYPES -> "ntitle:text_en,nrating:string")
+      csvDF.write.options(solrOpts).solr(collectionName)
+
+      // Explicit commit to make sure all docs are visible
+      val solrCloudClient = SolrSupport.getCachedCloudClient(zkHost)
+      solrCloudClient.commit(collectionName, true, true)
+
+      val solrBaseUrl = SolrSupport.getSolrBaseUrl(zkHost)
+      val solrUrl = solrBaseUrl + collectionName + "/"
+
+      val fieldTypes = SolrQuerySupport.getFieldTypes(Set.empty, solrUrl, cloudClient, collectionName)
+      assert(fieldTypes("nrating").fieldType === "string")
+      assert(fieldTypes("ntitle").fieldType === "text_en")
+    } finally {
+      SolrCloudUtil.deleteCollection(collectionName, cluster)
+    }
+  }
 }

--- a/src/test/scala/com/lucidworks/spark/TestSolrRelation.scala
+++ b/src/test/scala/com/lucidworks/spark/TestSolrRelation.scala
@@ -1,5 +1,10 @@
 package com.lucidworks.spark
 
+import com.lucidworks.spark.util.SolrRelationUtil
+import org.apache.solr.client.solrj.SolrQuery
+import org.apache.spark.sql.sources.{And, EqualTo, Or}
+import org.apache.spark.sql.types.{DataTypes, StructField, StructType}
+
 class TestSolrRelation extends SparkSolrFunSuite with SparkSolrContextBuilder {
 
   test("empty solr relation") {
@@ -19,4 +24,15 @@ class TestSolrRelation extends SparkSolrFunSuite with SparkSolrContextBuilder {
     val relation = new SolrRelation(options, None, sparkSession)
     assert(relation != null)
   }
+
+  test("Scala filter expressions") {
+    val filterExpr = Or(And(EqualTo("gender", "F"), EqualTo("artist", "Bernadette Peters")),And(EqualTo("gender", "M"), EqualTo("artist", "Girl Talk")))
+    val solrQuery = new SolrQuery
+    val schema = StructType(Seq(StructField("gender", DataTypes.StringType), StructField("artist", DataTypes.StringType)))
+    SolrRelationUtil.applyFilter(filterExpr, solrQuery, schema)
+    val fq = solrQuery.getFilterQueries
+    assert(fq.length == 1)
+    assert(fq(0) === """((gender:"F" AND artist:"Bernadette Peters") OR (gender:"M" AND artist:"Girl Talk"))""")
+  }
+
 }

--- a/src/test/scala/com/lucidworks/spark/TestSolrRelation.scala
+++ b/src/test/scala/com/lucidworks/spark/TestSolrRelation.scala
@@ -35,4 +35,12 @@ class TestSolrRelation extends SparkSolrFunSuite with SparkSolrContextBuilder {
     assert(fq(0) === """((gender:"F" AND artist:"Bernadette Peters") OR (gender:"M" AND artist:"Girl Talk"))""")
   }
 
+  test("custom field types option") {
+    val fieldTypeOption = "a:b,c,d:e"
+    val fieldTypes = SolrRelation.parseUserSuppliedFieldTypes(fieldTypeOption)
+    assert(fieldTypes.size ===  2)
+    assert(fieldTypes.keySet === Set("a", "d"))
+    assert(fieldTypes("a") === "b")
+    assert(fieldTypes("d") === "e")
+  }
 }


### PR DESCRIPTION
* Upgrade to Spark 2.3.1
* Fix nested filters in SQL
* Provide option for user to specify field type for fields while indexing