### PR TITLE
Add update_schema parameter for indexing

### DIFF
--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -108,6 +108,9 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
   def samplePct: Option[Float] =
     if (config.get(SAMPLE_PCT).isDefined) Some(config(SAMPLE_PCT).toFloat) else None
 
+  def updateSchema: Option[Boolean] =
+    if (config.get(UPDATE_SCHEMA).isDefined) Some(config(UPDATE_SCHEMA).toBoolean) else None
+
   def requestHandler: Option[String] = {
 
     if (!config.contains(REQUEST_HANDLER) && config.contains(SOLR_STREAMING_EXPR) && config.get(SOLR_STREAMING_EXPR).isDefined) {
@@ -268,6 +271,9 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
     }
     if (getSolrFieldTypes.isDefined) {
       sb ++= s", ${SOLR_FIELD_TYPES}=${getSolrFieldTypes.get}"
+    }
+    if (updateSchema.isDefined) {
+      sb ++= s", ${UPDATE_SCHEMA}=${updateSchema.get}"
     }
     sb ++= ")"
     sb.toString

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -31,6 +31,7 @@ object ConfigurationConstants {
   val COMMIT_WITHIN_MILLI_SECS: String = "commit_within"
   val CHILD_DOC_FIELDNAME: String = "child_doc_fieldname"
   val SOLR_FIELD_TYPES: String = "solr_field_types"
+  val UPDATE_SCHEMA: String = "update_schema"
 
   val SAMPLE_SEED: String = "sample_seed"
   val SAMPLE_PCT: String = "sample_pct"


### PR DESCRIPTION
This allows bypassing updating the solr schema when indexing if so
desired. The use case is that we manage all of our schema manually.