### PR TITLE
Remove typesafe dependency for logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,10 +350,6 @@
                   <shadedPattern>shaded.apache.commons.cli</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.typesafe.scalalogging</pattern>
-                  <shadedPattern>shaded.typesafe.scalalogging</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.apache.http</pattern>
                   <shadedPattern>shaded.apache.http</shadedPattern>
 		</relocation>
@@ -608,11 +604,6 @@
       <groupId>org.joda</groupId>
       <artifactId>joda-convert</artifactId>
       <version>1.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.typesafe.scala-logging</groupId>
-      <artifactId>scala-logging_${scala.binary.version}</artifactId>
-      <version>3.4.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>

--- a/src/main/java/com/lucidworks/spark/query/SparkSolrClientCache.java
+++ b/src/main/java/com/lucidworks/spark/query/SparkSolrClientCache.java
@@ -14,8 +14,6 @@ import java.lang.invoke.MethodHandles;
  */
 public class SparkSolrClientCache extends SolrClientCache {
 
-  private static final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
-
   private final CloudSolrClient solrClient;
   private final HttpSolrClient httpSolrClient;
 

--- a/src/main/java/com/lucidworks/spark/query/StreamingExpressionResultIterator.java
+++ b/src/main/java/com/lucidworks/spark/query/StreamingExpressionResultIterator.java
@@ -1,6 +1,5 @@
 package com.lucidworks.spark.query;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.apache.solr.client.solrj.impl.CloudSolrClient;
 import org.apache.solr.client.solrj.impl.HttpSolrClient;

--- a/src/main/scala/com/lucidworks/spark/JsonFacetUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/JsonFacetUtil.scala
@@ -1,6 +1,5 @@
 package com.lucidworks.spark
 
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}

--- a/src/main/scala/com/lucidworks/spark/Logging.scala
+++ b/src/main/scala/com/lucidworks/spark/Logging.scala
@@ -1,0 +1,65 @@
+package com.lucidworks.spark
+
+import org.slf4j.{LoggerFactory, Logger => Underlying}
+
+
+final class Logger private (val underlying: Underlying) extends Serializable {
+
+  def info(msg: String): Unit = if (underlying.isInfoEnabled) underlying.info(msg)
+
+  def info(msg: String, t: Throwable): Unit = if (underlying.isInfoEnabled) underlying.info(msg, t)
+
+  def info(msg: String, args: Any*): Unit = if (underlying.isInfoEnabled) underlying.info(msg, args)
+
+  def debug(msg: String): Unit = if (underlying.isDebugEnabled) underlying.debug(msg)
+
+  def debug(msg: String, t: Throwable): Unit = if (underlying.isDebugEnabled) underlying.debug(msg, t)
+
+  def debug(msg: String, args: Any*): Unit = if (underlying.isDebugEnabled) underlying.debug(msg, args)
+
+  def trace(msg: String): Unit = if (underlying.isTraceEnabled) underlying.trace(msg)
+
+  def trace(msg: String, t: Throwable): Unit = if (underlying.isTraceEnabled) underlying.trace(msg, t)
+
+  def trace(msg: String, args: Any*): Unit = if (underlying.isTraceEnabled) underlying.trace(msg, args)
+
+  def error(msg: String): Unit = if (underlying.isErrorEnabled) underlying.error(msg)
+
+  def error(msg: String, t: Throwable): Unit = if (underlying.isErrorEnabled) underlying.error(msg, t)
+
+  def error(msg: String, args: Any*): Unit = if (underlying.isErrorEnabled) underlying.error(msg, args)
+
+  def warn(msg: String): Unit = if (underlying.isWarnEnabled) underlying.warn(msg)
+
+  def warn(msg: String, t: Throwable): Unit = if (underlying.isWarnEnabled) underlying.warn(msg, t)
+
+  def warn(msg: String, args: Any*): Unit = if (underlying.isWarnEnabled) underlying.warn(msg, args)
+
+}
+
+/**
+  * Companion for [[Logger]], providing a factory for [[Logger]]s.
+  */
+object Logger {
+
+  /**
+    * Create a [[Logger]] wrapping the given underlying `org.slf4j.Logger`.
+    */
+  def apply(underlying: Underlying): Logger =
+    new Logger(underlying)
+
+  /**
+    * Create a [[Logger]] wrapping the created underlying `org.slf4j.Logger`.
+    */
+  def apply(clazz: Class[_]): Logger =
+    new Logger(LoggerFactory.getLogger(clazz.getName))
+}
+
+
+trait LazyLogging {
+  protected lazy val logger: Logger = Logger(LoggerFactory.getLogger(getClass.getName))
+}
+
+trait StrictLogging {
+  protected val logger: Logger = Logger(LoggerFactory.getLogger(getClass.getName))
+}

--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -3,7 +3,6 @@ package com.lucidworks.spark
 import com.lucidworks.spark.util.ConfigurationConstants._
 import com.lucidworks.spark.util.QueryConstants._
 import com.lucidworks.spark.util.SolrRelationUtil
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.common.params.ModifiableSolrParams
 
 class SolrConf(config: Map[String, String]) extends Serializable with LazyLogging {

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -9,7 +9,6 @@ import com.lucidworks.spark.rdd.{SolrRDD, StreamingSolrRDD}
 import com.lucidworks.spark.util.ConfigurationConstants._
 import com.lucidworks.spark.util.QueryConstants._
 import com.lucidworks.spark.util._
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.lang.StringUtils
 import org.apache.commons.lang3.StringEscapeUtils
 import org.apache.solr.client.solrj.SolrQuery.SortClause

--- a/src/main/scala/com/lucidworks/spark/TimePartitioningQuery.scala
+++ b/src/main/scala/com/lucidworks/spark/TimePartitioningQuery.scala
@@ -5,7 +5,6 @@ import java.util.{Date, TimeZone}
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.SolrQuery
 
 import scala.collection.JavaConverters._

--- a/src/main/scala/com/lucidworks/spark/example/NewRDDExample.scala
+++ b/src/main/scala/com/lucidworks/spark/example/NewRDDExample.scala
@@ -1,14 +1,13 @@
 package com.lucidworks.spark.example
 
-import com.lucidworks.spark.SparkApp
+import com.lucidworks.spark.{LazyLogging, SparkApp}
 import com.lucidworks.spark.rdd.SelectSolrRDD
 import com.lucidworks.spark.util.SolrSupport
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.cli.{CommandLine, Option}
 import org.apache.solr.client.solrj.request.CollectionAdminRequest
 import org.apache.spark.{SparkConf, SparkContext}
 
-class NewRDDExample extends SparkApp.RDDProcessor with LazyLogging{
+class NewRDDExample extends SparkApp.RDDProcessor with LazyLogging {
 
   override def getName: String = "new-rdd-example"
 

--- a/src/main/scala/com/lucidworks/spark/example/RDDExample.scala
+++ b/src/main/scala/com/lucidworks/spark/example/RDDExample.scala
@@ -1,9 +1,8 @@
 package com.lucidworks.spark.example
 
-import com.lucidworks.spark.SparkApp
+import com.lucidworks.spark.{LazyLogging, SparkApp}
 import com.lucidworks.spark.rdd.SelectSolrRDD
 import com.lucidworks.spark.util.SolrSupport
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.cli.{CommandLine, Option}
 import org.apache.solr.client.solrj.request.CollectionAdminRequest
 import org.apache.spark.{SparkConf, SparkContext}

--- a/src/main/scala/com/lucidworks/spark/example/ml/NewsgroupsIndexer.scala
+++ b/src/main/scala/com/lucidworks/spark/example/ml/NewsgroupsIndexer.scala
@@ -3,11 +3,10 @@ package com.lucidworks.spark.example.ml
 import java.net.URI
 import java.util.Locale
 
-import com.lucidworks.spark.SparkApp
+import com.lucidworks.spark.{LazyLogging, SparkApp}
 import com.lucidworks.spark.util.SolrSupport
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.cli.CommandLine
-import org.apache.commons.cli.Option.{builder => OptionBuilder} // Avoid clash with Scala Option
+import org.apache.commons.cli.Option.{builder => OptionBuilder}
 import org.apache.solr.common.SolrInputDocument
 import org.apache.spark.{SparkConf, SparkContext}
 import org.apache.spark.input.PortableDataStream

--- a/src/main/scala/com/lucidworks/spark/ml/feature/LuceneTextAnalyzerTransformer.scala
+++ b/src/main/scala/com/lucidworks/spark/ml/feature/LuceneTextAnalyzerTransformer.scala
@@ -19,8 +19,8 @@ package com.lucidworks.spark.ml.feature
 
 import java.io.{PrintWriter, StringWriter}
 
+import com.lucidworks.spark.LazyLogging
 import com.lucidworks.spark.analysis.LuceneTextAnalyzer
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.lucene.analysis.tokenattributes.CharTermAttribute
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.ml.param.{Param, _}
@@ -158,7 +158,7 @@ class LuceneTextAnalyzerTransformer(override val uid: String) extends HasInputCo
       buildReferencedAnalyzers()
     }
     require(analyzer.exists(_.isValid),
-      analyzer.map(_.invalidMessages).getOrElse(analyzerInitFailure.get))
+      analyzer.map(_.invalidMessages).getOrElse(analyzerInitFailure.getOrElse(s"Invalid analyzer ${analyzer}")))
   }
 
   private def buildReferencedAnalyzers(): Unit = {

--- a/src/main/scala/com/lucidworks/spark/rdd/SelectSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SelectSolrRDD.scala
@@ -3,8 +3,7 @@ package com.lucidworks.spark.rdd
 import com.lucidworks.spark.query.StreamingResultsIterator
 import com.lucidworks.spark.util.QueryConstants._
 import com.lucidworks.spark.util.{SolrQuerySupport, SolrSupport}
-import com.lucidworks.spark.{SelectSolrRDDPartition, SolrLimitPartition, SolrPartitioner, SparkSolrAccumulator}
-import com.typesafe.scalalogging.LazyLogging
+import com.lucidworks.spark._
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.common.SolrDocument
 import org.apache.solr.common.params.ShardParams

--- a/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/SolrRDD.scala
@@ -3,7 +3,6 @@ package com.lucidworks.spark.rdd
 import com.lucidworks.spark._
 import com.lucidworks.spark.util.QueryConstants._
 import com.lucidworks.spark.util.{CacheCloudSolrClient, CacheHttpSolrClient, SolrQuerySupport}
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.spark._
 import org.apache.spark.rdd.RDD

--- a/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
@@ -3,8 +3,7 @@ package com.lucidworks.spark.rdd
 import com.lucidworks.spark.query.{SolrStreamIterator, StreamingExpressionResultIterator, TupleStreamIterator}
 import com.lucidworks.spark.util.QueryConstants._
 import com.lucidworks.spark.util.{SolrQuerySupport, SolrSupport}
-import com.lucidworks.spark.{CloudStreamPartition, ExportHandlerPartition, SolrPartitioner, SparkSolrAccumulator}
-import com.typesafe.scalalogging.LazyLogging
+import com.lucidworks.spark._
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.common.params.ShardParams
 import org.apache.spark.annotation.DeveloperApi

--- a/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
@@ -3,10 +3,9 @@ package com.lucidworks.spark.util
 import java.net.URLDecoder
 import java.util
 
-import com.lucidworks.spark.JsonFacetUtil
+import com.lucidworks.spark.{JsonFacetUtil, LazyLogging}
 import com.lucidworks.spark.query._
 import com.lucidworks.spark.rdd.SolrRDD
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.SolrRequest.METHOD
 import org.apache.solr.client.solrj._
 import org.apache.solr.client.solrj.impl._

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -5,8 +5,8 @@ import java.sql.Timestamp
 import java.util
 import java.util.Date
 
+import com.lucidworks.spark.LazyLogging
 import com.lucidworks.spark.rdd.{SelectSolrRDD, StreamingSolrRDD}
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.request.GenericSolrRequest
 import org.apache.solr.client.solrj.request.RequestWriter.StringPayloadContentWriter
 import org.apache.solr.client.solrj.{SolrQuery, SolrRequest}

--- a/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
@@ -13,8 +13,7 @@ import com.google.common.cache._
 import com.lucidworks.spark.filter.DocFilterContext
 import com.lucidworks.spark.fusion.FusionPipelineClient
 import com.lucidworks.spark.util.SolrSupport.ShardInfo
-import com.lucidworks.spark.{SolrReplica, SolrShard, SparkSolrAccumulator}
-import com.typesafe.scalalogging.LazyLogging
+import com.lucidworks.spark.{LazyLogging, SolrReplica, SolrShard, SparkSolrAccumulator}
 import org.apache.commons.httpclient.NoHttpResponseException
 import org.apache.solr.client.solrj.impl._
 import org.apache.solr.client.solrj.request.UpdateRequest

--- a/src/test/scala/com/lucidworks/spark/RDDTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/RDDTestSuite.scala
@@ -6,7 +6,6 @@ import com.lucidworks.spark.rdd.{SelectSolrRDD, StreamingSolrRDD}
 import com.lucidworks.spark.util.ConfigurationConstants._
 import com.lucidworks.spark.util.QueryConstants._
 import com.lucidworks.spark.util.SolrCloudUtil
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.SolrQuery
 
 class RDDTestSuite extends TestSuiteBuilder with LazyLogging {

--- a/src/test/scala/com/lucidworks/spark/RelationTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/RelationTestSuite.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import com.lucidworks.spark.util.ConfigurationConstants._
 import com.lucidworks.spark.util.{SolrCloudUtil, SolrQuerySupport}
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.solr.client.solrj.request.{CollectionAdminRequest, UpdateRequest}
 import org.apache.solr.common.SolrInputDocument
 import org.apache.spark.sql.types.{DoubleType, LongType, StringType, TimestampType}

--- a/src/test/scala/com/lucidworks/spark/SparkSolrFunSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/SparkSolrFunSuite.scala
@@ -17,7 +17,6 @@
 
 package com.lucidworks.spark
 
-import com.typesafe.scalalogging.LazyLogging
 import org.scalatest.{FunSuite, Outcome}
 
 /**

--- a/src/test/scala/com/lucidworks/spark/TestFramework.scala
+++ b/src/test/scala/com/lucidworks/spark/TestFramework.scala
@@ -5,7 +5,6 @@ import java.util.UUID
 
 import com.lucidworks.spark.example.ml.DateConverter
 import com.lucidworks.spark.util.{EventsimUtil, SolrCloudUtil, SolrSupport}
-import com.typesafe.scalalogging.LazyLogging
 import org.apache.commons.io.FileUtils
 import org.apache.solr.client.solrj.impl.CloudSolrClient
 import org.apache.solr.cloud.MiniSolrCloudCluster

--- a/src/test/scala/com/lucidworks/spark/util/SolrCloudUtil.scala
+++ b/src/test/scala/com/lucidworks/spark/util/SolrCloudUtil.scala
@@ -2,7 +2,7 @@ package com.lucidworks.spark.util
 
 import java.io.File
 
-import com.typesafe.scalalogging.LazyLogging
+import com.lucidworks.spark.LazyLogging
 import org.apache.solr.client.solrj.SolrQuery
 import org.apache.solr.client.solrj.impl.CloudSolrClient
 import org.apache.solr.client.solrj.request.{CollectionAdminRequest, QueryRequest, UpdateRequest}


### PR DESCRIPTION
* typesafe dependency inside spark-solr has caused us problems with dep conflicts
* Last release of spark-solr doesn't play fine with stock Spark due to typesafe dependency conflicts
* This PR removes typesafe dependency and introduces our own logger similar to typesafe logger