### PR TITLE
Skip luke calls if schema is defined

### DIFF
--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -114,6 +114,8 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
   def samplePct: Option[Float] =
     if (config.get(SAMPLE_PCT).isDefined) Some(config(SAMPLE_PCT).toFloat) else None
 
+  def schema: Option[String] = config.get(SCHEMA)
+
   def requestHandler: Option[String] = {
 
     if (!config.contains(REQUEST_HANDLER) && config.contains(SOLR_STREAMING_EXPR) && config.get(SOLR_STREAMING_EXPR).isDefined) {

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -970,7 +970,7 @@ object SolrRelation extends LazyLogging {
   def parseSortParamFromString(sortParam: String):  List[SortClause] = {
     val sortClauses: ListBuffer[SortClause] = ListBuffer.empty
     for (pair <- sortParam.split(",")) {
-      val sortStringParams = pair.split(" ")
+      val sortStringParams = pair.trim.split(" ")
       if (sortStringParams.nonEmpty) {
         if (sortStringParams.size == 2) {
           sortClauses += new SortClause(sortStringParams(0), sortStringParams(1))

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -111,7 +111,15 @@ class SolrRelation(
       if (userRequestedFields.isDefined) {
         // filter out any function query invocations from the base schema list
         val baseSchemaFields = userRequestedFields.get.filter(!_.funcReturnType.isDefined).map(_.name) ++ Array(uniqueKey)
-        baseSchema = Some(getBaseSchemaFromConfig(collection, baseSchemaFields))
+        if (conf.schema.isEmpty) {
+          baseSchema = Some(getBaseSchemaFromConfig(collection, baseSchemaFields))
+        } else {
+          val fieldSet = SolrRelation.parseSchemaExprSchemaToStructFields(conf.schema.get)
+          if (fieldSet.isEmpty) {
+            throw new IllegalStateException(s"Failed to extract schema fields from schema config ${schema}")
+          }
+          baseSchema = Some(new StructType(fieldSet.toArray.sortBy(f => f.name)))
+        }
         SolrRelationUtil.deriveQuerySchema(userRequestedFields.get, baseSchema.get)
       } else if (initialQuery.getRequestHandler == QT_STREAM) {
         var fieldSet: scala.collection.mutable.Set[StructField] = scala.collection.mutable.Set[StructField]()

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -46,6 +46,7 @@ object ConfigurationConstants {
 
   val ARBITRARY_PARAMS_STRING: String = "solr.params"
 
+  val SCHEMA: String = "schema"
   val STREAMING_EXPR_SCHEMA: String = "expr_schema"
   val SOLR_SQL_SCHEMA: String = "sql_schema"
   val EXCLUDE_FIELDS: String = "exclude_fields"

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -93,6 +93,7 @@ object SolrRelationUtil extends LazyLogging {
         logger.debug("Fields from luke handler: {}", fieldsFromLuke.mkString(","))
         if (fieldsFromLuke.isEmpty)
           return new StructType()
+        // Retain the keys that are present in the Luke handler
         SolrQuerySupport.getFieldTypes(fieldsFromLuke, solrUrl, cloudClient, collection).filterKeys(fieldsFromLuke.contains)
       } else {
         SolrQuerySupport.getFieldTypes(fields, solrUrl, cloudClient, collection)
@@ -101,7 +102,6 @@ object SolrRelationUtil extends LazyLogging {
     logger.debug("Fields from schema handler: {}", fieldTypeMap.keySet.mkString(","))
     val structFields = new ListBuffer[StructField]
 
-    // Retain the keys that are present in the Luke handler
     fieldTypeMap.foreach{ case(fieldName, fieldMeta) =>
       val metadata = new MetadataBuilder
       var dataType: DataType = {

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -84,24 +84,25 @@ object SolrRelationUtil extends LazyLogging {
     if (SolrQuerySupport.getNumDocsFromSolr(collection, zkHost, None) == 0)
       return new StructType()
 
+    val cloudClient = SolrSupport.getCachedCloudClient(zkHost)
     val solrBaseUrl = SolrSupport.getSolrBaseUrl(zkHost)
     val solrUrl = solrBaseUrl + collection + "/"
-    val fieldsFromLuke = SolrQuerySupport.getFieldsFromLuke(zkHost, collection)
-    logger.debug("Fields from luke handler: {}", fieldsFromLuke.mkString(","))
-    if (fieldsFromLuke.isEmpty)
-      return new StructType()
-
-    val cloudClient = SolrSupport.getCachedCloudClient(zkHost)
     val fieldTypeMap =
-      if (fields.isEmpty)
-        SolrQuerySupport.getFieldTypes(fieldsFromLuke, solrUrl, cloudClient, collection)
-      else
+      if (fields.isEmpty) {
+        val fieldsFromLuke = SolrQuerySupport.getFieldsFromLuke(zkHost, collection)
+        logger.debug("Fields from luke handler: {}", fieldsFromLuke.mkString(","))
+        if (fieldsFromLuke.isEmpty)
+          return new StructType()
+        SolrQuerySupport.getFieldTypes(fieldsFromLuke, solrUrl, cloudClient, collection).filterKeys(fieldsFromLuke.contains)
+      } else {
         SolrQuerySupport.getFieldTypes(fields, solrUrl, cloudClient, collection)
+      }
+
     logger.debug("Fields from schema handler: {}", fieldTypeMap.keySet.mkString(","))
     val structFields = new ListBuffer[StructField]
 
     // Retain the keys that are present in the Luke handler
-    fieldTypeMap.filterKeys(f => fieldsFromLuke.contains(f)).foreach{ case(fieldName, fieldMeta) =>
+    fieldTypeMap.foreach{ case(fieldName, fieldMeta) =>
       val metadata = new MetadataBuilder
       var dataType: DataType = {
         if (fieldMeta.fieldTypeClass.isDefined) {

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -167,7 +167,7 @@ object SolrRelationUtil extends LazyLogging {
     for (structField <- schema.fields) fieldMap.put(structField.name, structField)
 
     val listOfFields = new ListBuffer[StructField]
-    for (field <- fields) {
+    for (field <- fields.distinct) {
       if (field.funcReturnType.isDefined) {
         listOfFields.add(DataTypes.createStructField(field.alias.get, field.funcReturnType.get, false, Metadata.empty))
       } else {

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -46,6 +46,45 @@ class EventsimTestSuite extends EventsimBuilder {
     assert(singleRow.length == 2)
   }
 
+  test("Sort by two fields") {
+    val df = sparkSession.read.format("solr")
+      .option(SOLR_ZK_HOST_PARAM, zkHost)
+      .option(SOLR_COLLECTION_PARAM, collectionName)
+      .option(SOLR_FIELD_PARAM, "userId, ts")
+      .option(SOLR_QUERY_PARAM, "userId:93")
+      .option(SORT_PARAM, "userId asc, ts asc")
+      .load()
+    val singleRow = df.take(1)(0)
+    assert(singleRow.length == 2)
+    assert(singleRow(df.schema.fieldIndex("userId")).toString.toInt == 93)
+  }
+
+  test("Alias and Sort by field") {
+    val df = sparkSession.read.format("solr")
+      .option(SOLR_ZK_HOST_PARAM, zkHost)
+      .option(SOLR_COLLECTION_PARAM, collectionName)
+      .option(SOLR_FIELD_PARAM, "user:userId,userId")
+      .option(SCHEMA, """userId:\"string\"""")
+      .load()
+    df.printSchema()
+    val singleRow = df.take(1)(0)
+    assert(singleRow.length == 2)
+  }
+
+  test("Sort by score") {
+    val df = sparkSession.read.format("solr")
+      .option(SOLR_ZK_HOST_PARAM, zkHost)
+      .option(SOLR_COLLECTION_PARAM, collectionName)
+      .option(SOLR_FIELD_PARAM, "userId, ts")
+      .option(SOLR_QUERY_PARAM, "userId:93")
+      .option(SORT_PARAM, "score asc")
+      .option(MAX_ROWS, "5")
+      .load()
+    val singleRow = df.take(1)(0)
+    assert(singleRow.length == 2)
+    assert(singleRow(df.schema.fieldIndex("userId")).toString.toInt == 93)
+  }
+
   test("SQL fields option") {
     val df = sparkSession.read.format("solr")
       .option(SOLR_ZK_HOST_PARAM, zkHost)

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -34,6 +34,18 @@ class EventsimTestSuite extends EventsimBuilder {
     testCommons(solrRDD)
   }
 
+  test("User requested fields with schema") {
+    val df = sparkSession.read.format("solr")
+      .option(SOLR_ZK_HOST_PARAM, zkHost)
+      .option(SOLR_COLLECTION_PARAM, collectionName)
+      .option(SOLR_FIELD_PARAM, "userId, ts")
+      .option(SOLR_QUERY_PARAM, "userId:93")
+      .option(SCHEMA, "userId:string,ts:timestamp")
+      .load()
+    val singleRow = df.take(1)(0)
+    assert(singleRow.length == 2)
+  }
+
   test("SQL fields option") {
     val df = sparkSession.read.format("solr")
       .option(SOLR_ZK_HOST_PARAM, zkHost)


### PR DESCRIPTION
* Skip luke call if user has explicitly requested for fields using `fields` config param
* Skip luke and schema call if user explicitly sets the schema using `schema` config param
* Luke is a very expensive call (especially since it hits each shard) for SQL type queries