### PR TITLE
Makes multivalued handled within ChildDocuments

### DIFF
--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -684,7 +684,17 @@ class SolrRelation(
                 val elem = it.next()
                 val childDoc = new SolrInputDocument
                 for (i <- 0 until elem.schema.fields.size) {
-                  childDoc.setField(elem.schema.fields(i).name, elem.get(i))
+                    val childFname = elem.schema.fields(i).name
+                    val childValue = elem.get(i)
+                    childValue match {
+                      //TODO: Do we need to check explicitly for ArrayBuffer and WrappedArray
+                      case v: Iterable[Any] =>
+                        val it = v.iterator
+                        while (it.hasNext) childDoc.addField(childFname, it.next())
+                      case bd: java.math.BigDecimal =>
+                        childDoc.setField(childFname, bd.doubleValue())
+                      case _ => childDoc.setField(childFname, childValue)
+                    }
                 }
 
                 // Generate unique key if the child document doesn't have one


### PR DESCRIPTION
This patch fixes the problem with childDocuments and multi valued works. This is related to #240 