### PR TITLE
APOLLO-18556: Don't fetch index flags from /luke

### DIFF
--- a/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrQuerySupport.scala
@@ -65,6 +65,20 @@ class QueryResultsIterator(
   override protected def processQueryResponse(resp: QueryResponse): util.List[SolrDocument] = resp.getResults
 }
 
+/**
+  * SolrJ's {@link LukeRequest} doesn't support the 'includeIndexFieldFlags', so this stub class hardcodes it into the
+  * underlying SolrParams until this can be fixed in Solr. This can be removed once our SolrJ has the fix for
+  * SOLR-13362
+  */
+class LukeRequestWithoutIndexFlags extends LukeRequest {
+  override def getParams: SolrParams = {
+    val params = new ModifiableSolrParams(super.getParams)
+    params.add("includeIndexFieldFlags", "false")
+
+    params
+  }
+}
+
 object SolrQuerySupport extends LazyLogging {
 
   val SOLR_DATA_TYPES: Map[String, DataType] = HashMap(
@@ -482,7 +496,7 @@ object SolrQuerySupport extends LazyLogging {
   }
 
   def getFieldsFromLukePerShard(zkHost: String, httpSolrClient: HttpSolrClient): Set[String] = {
-    val lukeRequest = new LukeRequest()
+    val lukeRequest = new LukeRequestWithoutIndexFlags()
     lukeRequest.setNumTerms(0)
     val lukeResponse = lukeRequest.process(httpSolrClient)
     if (lukeResponse.getStatus != 0) {


### PR DESCRIPTION
By default, /luke fetches index flags for all fields it returns.  This
can be expensive when shards have a large number of fields.  We only
use /luke to fetch the field-names, so this commit adds the
'includeIndexFieldFlags=false' flag to our /luke calls so they avoid
this slowdown.