### PR TITLE
Upgrade spark and solr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,10 +37,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <spark.version>2.4.0</spark.version>
-    <solr.version>7.6.0</solr.version>
+    <spark.version>2.4.3</spark.version>
+    <solr.version>7.7.1</solr.version>
     <fasterxml.version>2.4.0</fasterxml.version>
-    <scala.version>2.11.8</scala.version>
+    <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
     <fasterxml.version>2.4.0</fasterxml.version>
@@ -547,7 +547,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.11</version>
+      <version>4.12</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/scala/com/lucidworks/spark/TestQuerying.scala
+++ b/src/test/scala/com/lucidworks/spark/TestQuerying.scala
@@ -11,7 +11,7 @@ class TestQuerying extends TestSuiteBuilder {
 
   test("Solr version") {
     val solrVersion = SolrSupport.getSolrVersion(zkHost)
-    assert(solrVersion == "7.6.0")
+    assert(solrVersion == "7.7.1")
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 7, 5, 0))
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 7, 3, 0))
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 7, 1, 0))


### PR DESCRIPTION
Upgrade

*  Spark to 2.4.3
*  Solr to 7.7.1
*  Scala to 2.11.12
* Junit to 4.12

I tried upgrading to Solr 8.1 but it seems to be a more involved effort that needs to be evaluated. We should do that as a separate PR