### PR TITLE
changed httpclient 3.1 class imports to httpclient 4.x equivalent classes

### DIFF
--- a/src/main/java/com/lucidworks/spark/fusion/FusionPipelineClient.java
+++ b/src/main/java/com/lucidworks/spark/fusion/FusionPipelineClient.java
@@ -5,7 +5,7 @@ import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.scala.DefaultScalaModule;
-import org.apache.commons.httpclient.ConnectTimeoutException;
+import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.*;

--- a/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
@@ -14,7 +14,7 @@ import com.lucidworks.spark.filter.DocFilterContext
 import com.lucidworks.spark.fusion.FusionPipelineClient
 import com.lucidworks.spark.util.SolrSupport.ShardInfo
 import com.lucidworks.spark.{LazyLogging, SolrReplica, SolrShard, SparkSolrAccumulator}
-import org.apache.commons.httpclient.NoHttpResponseException
+import org.apache.http.NoHttpResponseException
 import org.apache.solr.client.solrj.impl._
 import org.apache.solr.client.solrj.request.UpdateRequest
 import org.apache.solr.client.solrj.response.QueryResponse


### PR DESCRIPTION
Changed the httpclient 3.1 class imports to httpclient 4.x class imports. This
would affect anyone trying to exclude spark-solr's hadoop dependencies and include
newer hadoop dependencies for other purposes. This didn't seem to break anything -- the 
tests passed, the project compiled, and our spark jobs worked! -- but we don't utilize any of 
the hadoop/hdfs features of the spark-solr connector. However, this PR should be harmless.
Reference issue here: lucidworks/spark-solr#272