### PR TITLE
APOLLO-20848: Upgrade Solr to 8.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <spark.version>2.4.3</spark.version>
-    <solr.version>8.1.1</solr.version>
+    <solr.version>8.2.0</solr.version>
     <hadoop.version>2.7.5</hadoop.version>
     <fasterxml.version>2.9.9</fasterxml.version>
     <scala.version>2.11.12</scala.version>
@@ -413,6 +413,14 @@
         <exclusion>
           <groupId>io.dropwizard.metrics</groupId>
           <artifactId>metrics-graphite</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.zookeeper</groupId>
+          <artifactId>zookeeper</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-recipes</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/src/test/scala/com/lucidworks/spark/TestQuerying.scala
+++ b/src/test/scala/com/lucidworks/spark/TestQuerying.scala
@@ -11,11 +11,12 @@ class TestQuerying extends TestSuiteBuilder {
 
   test("Solr version") {
     val solrVersion = SolrSupport.getSolrVersion(zkHost)
-    assert(solrVersion == "8.1.1")
+    assert(solrVersion == "8.2.0")
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 7, 5, 0))
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 7, 3, 0))
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 7, 1, 0))
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 8, 0, 0))
+    assert(SolrSupport.isSolrVersionAtleast(solrVersion, 8, 1, 0))
     assert(!SolrSupport.isSolrVersionAtleast(solrVersion, 9, 0, 0))
   }
 


### PR DESCRIPTION
Brings in latest Solr version.  Solr depends on ZooKeeper 3.5.5 now, so
this changes our effective ZooKeeper and Curator versions as well.