### PR TITLE
APOLLO-22156-added-gpg-arguments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,13 @@
                 <phase>verify</phase>
                 <goals>
                   <goal>sign</goal>
-                </goals>
+	        </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
New version of gpg requires these arguments for pulling the passphrase from the settings.xml file