### PR TITLE
Add Spark streaming

### DIFF
--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -14,8 +14,8 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
   def getZkHost: Option[String] = {
     if (config.contains(SOLR_ZK_HOST_PARAM)) return config.get(SOLR_ZK_HOST_PARAM)
 
-    // allow users to set the zkhost using a Java system property
-    var zkHostSysProp = System.getProperty("solr.zkhost")
+    // allow users to set the zkhost using a Java system property or env property
+    val zkHostSysProp = System.getProperty("solr.zkhost", System.getenv("SOLR_ZKHOST"))
     if (zkHostSysProp != null) return Some(zkHostSysProp)
 
     None

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -1067,10 +1067,10 @@ object SolrRelation extends LazyLogging {
     map += ("name" -> sf.name)
     map += ("indexed" -> "true")
     map += ("stored" -> "true")
-    if (solrType.isEmpty) {
-      map += ("docValues" -> "true")
-    }
     val dataType = sf.dataType
+    if (solrType.isEmpty) {
+      map += ("docValues" -> isDocValuesSupported(dataType))
+    }
     dataType match {
       case at: ArrayType =>
         map += ("multiValued" -> "true")
@@ -1098,6 +1098,13 @@ object SolrRelation extends LazyLogging {
       case IntegerType | ShortType => "tint"
       case LongType => "tlong"
       case _ => "string"
+    }
+  }
+
+  def isDocValuesSupported(dataType: DataType): String = {
+    dataType match {
+      case BinaryType => "false"
+      case _ => "true"
     }
   }
 

--- a/src/main/scala/com/lucidworks/spark/SolrStreamWriter.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrStreamWriter.scala
@@ -1,0 +1,61 @@
+package com.lucidworks.spark
+
+import com.lucidworks.spark.util.{SolrQuerySupport, SolrSupport}
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.execution.streaming.Sink
+import org.apache.spark.sql.streaming.OutputMode
+import com.lucidworks.spark.util.ConfigurationConstants._
+import org.apache.spark.sql.types.StructType
+
+/**
+  * Writes a Spark stream to Solr
+  * @param sparkSession
+  * @param parameters
+  * @param partitionColumns
+  * @param outputMode
+  * @param solrConf
+  */
+class SolrStreamWriter(
+    val sparkSession: SparkSession,
+    parameters: Map[String, String],
+    val partitionColumns: Seq[String],
+    val outputMode: OutputMode)(
+  implicit val solrConf : SolrConf = new SolrConf(parameters))
+  extends Sink with LazyLogging {
+
+  require(solrConf.getZkHost.isDefined, s"Parameter ${SOLR_ZK_HOST_PARAM} not defined")
+  require(solrConf.getCollection.isDefined, s"Parameter ${SOLR_COLLECTION_PARAM} not defined")
+
+  val collection : String = solrConf.getCollection.get
+  val zkhost: String = solrConf.getZkHost.get
+
+  lazy val solrVersion : String = SolrSupport.getSolrVersion(solrConf.getZkHost.get)
+  lazy val uniqueKey: String = SolrQuerySupport.getUniqueKey(zkhost, collection.split(",")(0))
+
+  lazy val dynamicSuffixes: Set[String] = SolrQuerySupport.getFieldTypes(
+      Set.empty,
+      SolrSupport.getSolrBaseUrl(zkhost),
+      SolrSupport.getCachedCloudClient(zkhost),
+      collection,
+      skipDynamicExtensions = false)
+    .keySet
+    .filter(f => f.startsWith("*_") || f.endsWith("_*"))
+    .map(f => if (f.startsWith("*_")) f.substring(1) else f.substring(0, f.length-1))
+
+  override def addBatch(batchId: Long, df: DataFrame): Unit = {
+    val schema: StructType = df.schema
+    val solrClient = SolrSupport.getCachedCloudClient(zkhost)
+
+    // build up a list of updates to send to the Solr Schema API
+    val fieldsToAddToSolr = SolrRelation.getFieldsToAdd(schema, solrConf, solrVersion, dynamicSuffixes)
+
+    if (fieldsToAddToSolr.nonEmpty) {
+      SolrRelation.addFieldsForInsert(fieldsToAddToSolr, collection, solrClient)
+    }
+
+    val rows = df.collect()
+    val solrDocs = rows.toStream.map(row => SolrRelation.convertRowToSolrInputDocument(row, solrConf, uniqueKey))
+    SolrSupport.sendBatchToSolrWithRetry(zkhost, solrClient, collection, solrDocs, solrConf.commitWithin)
+    logger.info("Written {} documents to Solr collection {}", rows.length, collection)
+  }
+}

--- a/src/main/scala/com/lucidworks/spark/analysis/LuceneTextAnalyzer.scala
+++ b/src/main/scala/com/lucidworks/spark/analysis/LuceneTextAnalyzer.scala
@@ -187,7 +187,7 @@ class LuceneTextAnalyzer(analysisSchema: String) extends Serializable {
     val output = new java.util.HashMap[String,java.util.List[String]]()
     for ((field, values) <- fieldValues) output.put(field, analyzeMVJava(field, values))
     java.util.Collections.unmodifiableMap(output)
-  }eventSimCount
+  }
   def tokenStream(fieldName: String, text: String) = analyzerWrapper.tokenStream(fieldName, text)
   /** Looks up the analyzer mapped to `fieldName` and returns a [[org.apache.lucene.analysis.TokenStream]]
     * for the analyzer to tokenize the contents of `reader`. */

--- a/src/main/scala/com/lucidworks/spark/analysis/LuceneTextAnalyzer.scala
+++ b/src/main/scala/com/lucidworks/spark/analysis/LuceneTextAnalyzer.scala
@@ -187,9 +187,7 @@ class LuceneTextAnalyzer(analysisSchema: String) extends Serializable {
     val output = new java.util.HashMap[String,java.util.List[String]]()
     for ((field, values) <- fieldValues) output.put(field, analyzeMVJava(field, values))
     java.util.Collections.unmodifiableMap(output)
-  }
-  /** Looks up the analyzer mapped to `fieldName` and returns a [[org.apache.lucene.analysis.TokenStream]]
-    * for the analyzer to tokenize the contents of `text`. */
+  }eventSimCount
   def tokenStream(fieldName: String, text: String) = analyzerWrapper.tokenStream(fieldName, text)
   /** Looks up the analyzer mapped to `fieldName` and returns a [[org.apache.lucene.analysis.TokenStream]]
     * for the analyzer to tokenize the contents of `reader`. */

--- a/src/main/scala/solr/DefaultSource.scala
+++ b/src/main/scala/solr/DefaultSource.scala
@@ -1,11 +1,13 @@
 package solr
 
-import com.lucidworks.spark.SolrRelation
+import com.lucidworks.spark.{SolrRelation, SolrStreamWriter}
 import com.lucidworks.spark.util.Constants
-import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
-import org.apache.spark.sql.sources.{DataSourceRegister, BaseRelation, CreatableRelationProvider, RelationProvider}
+import org.apache.spark.sql.execution.streaming.Sink
+import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
+import org.apache.spark.sql.sources._
+import org.apache.spark.sql.streaming.OutputMode
 
-class DefaultSource extends RelationProvider with CreatableRelationProvider with DataSourceRegister {
+class DefaultSource extends RelationProvider with CreatableRelationProvider with StreamSinkProvider with DataSourceRegister {
 
   override def createRelation(sqlContext: SQLContext, parameters: Map[String, String]): BaseRelation = {
     try {
@@ -33,4 +35,12 @@ class DefaultSource extends RelationProvider with CreatableRelationProvider with
   }
 
   override def shortName(): String = Constants.SOLR_FORMAT
+
+  override def createSink(
+      sqlContext: SQLContext,
+      parameters: Map[String, String],
+      partitionColumns: Seq[String],
+      outputMode: OutputMode): Sink = {
+    new SolrStreamWriter(sqlContext.sparkSession, parameters, partitionColumns, outputMode)
+  }
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -17,7 +17,10 @@ log4j.appender.stdout.layout.ConversionPattern=%d{ISO8601} [%t] %-5p %c{1} %x - 
 #log4j.logger.org.apache.spark.streaming=DEBUG
 #log4j.logger.org.apache.spark.streaming.receiver=DEBUG
 log4j.logger.org.apache.spark=WARN
+log4j.logger.org.apache.spark.sql.execution.streaming=INFO
+log4j.logger.org.apache.spark.sql.execution.WholeStageCodegenExec=WARN
 log4j.logger.org.apache.spark.storage.BlockManager=ERROR
+log4j.logger.org.apache.spark.sql.catalyst.expressions.codegen=WARN
 
 log4j.logger.org.apache.spark.ml.tuning.CrossValidator=INFO
 log4j.logger.com.lucidworks.spark.fusion.FusionPipelineClient=INFO

--- a/src/test/scala/com/lucidworks/spark/TestIndexing.scala
+++ b/src/test/scala/com/lucidworks/spark/TestIndexing.scala
@@ -78,8 +78,9 @@ class TestIndexing extends TestSuiteBuilder {
     try {
       SolrCloudUtil.buildCollection(zkHost, collection, null, 2, cloudClient, sc)
       val opts = Map("zkhost" -> zkHost, "collection" -> collection)
+
       val solrRelation = new SolrRelation(opts, sparkSession)
-      val fieldsToAdd = solrRelation.getFieldsToAdd(insertSchema)
+      val fieldsToAdd = SolrRelation.getFieldsToAdd(insertSchema, solrRelation.conf, solrRelation.solrVersion, solrRelation.dynamicSuffixes)
       assert(fieldsToAdd.isEmpty)
     } finally {
       SolrCloudUtil.deleteCollection(collection, cluster)

--- a/src/test/scala/com/lucidworks/spark/TestSolrStreamWriter.scala
+++ b/src/test/scala/com/lucidworks/spark/TestSolrStreamWriter.scala
@@ -1,0 +1,47 @@
+package com.lucidworks.spark
+
+import java.io.File
+import java.util.UUID
+
+import com.lucidworks.spark.util.{ConfigurationConstants, SolrCloudUtil, SolrQuerySupport, SolrSupport}
+import org.apache.commons.io.FileUtils
+
+class TestSolrStreamWriter extends TestSuiteBuilder {
+
+  test("Stream data into Solr") {
+    val collectionName = "testStreaming-" + UUID.randomUUID().toString
+    SolrCloudUtil.buildCollection(zkHost, collectionName, null, 1, cloudClient, sc)
+    sparkSession.conf.set("spark.sql.streaming.schemaInference", "true")
+    sparkSession.sparkContext.setLogLevel("DEBUG")
+    val offsetsDir = FileUtils.getTempDirectory + "/spark-stream-offsets-" + UUID.randomUUID().toString
+    try {
+      val datasetPath = "src/test/resources/test-data/oneusagov"
+      val streamingJsonDF = sparkSession.readStream.json(datasetPath)
+      assert(streamingJsonDF.isStreaming)
+      val writeOptions = Map(
+        "collection" -> collectionName,
+        "zkhost" -> zkHost,
+        "checkpointLocation" -> offsetsDir,
+        ConfigurationConstants.GENERATE_UNIQUE_KEY -> "true")
+      val streamingQuery = streamingJsonDF
+        .drop("_id")
+        .writeStream
+        .outputMode("append")
+        .format("solr")
+        .options(writeOptions)
+        .start()
+      try {
+        logger.info(s"Explain ${streamingQuery.explain()}")
+        streamingQuery.processAllAvailable()
+        logger.info(s"Status ${streamingQuery.status}")
+        SolrSupport.getCachedCloudClient(zkHost).commit(collectionName)
+        assert(SolrQuerySupport.getNumDocsFromSolr(collectionName, zkHost, None) === 13)
+      } finally {
+        streamingQuery.stop()
+      }
+    } finally {
+      SolrCloudUtil.deleteCollection(collectionName, cluster)
+      FileUtils.deleteDirectory(new File(offsetsDir))
+    }
+  }
+}


### PR DESCRIPTION
* Users can now stream data to Solr from any Spark supported datasource
* In order to preserve exactly once semantics, users should set `id` (primary field) field before streaming the data out to Solr