### PR TITLE
Revert "[SECURITY] Use HTTPS to resolve dependencies in Maven Build"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <repository>
       <id>Restlet Releases</id>
       <name>Restlet Releases Repository</name>
-      <url>https://maven.restlet.com/</url>
+      <url>http://maven.restlet.com/</url>
       <releases>
         <enabled>true</enabled>
       </releases>


### PR DESCRIPTION
Reverts lucidworks/spark-solr#286

Build failing to resolve deps

```
Caused by: org.sonatype.aether.transfer.ArtifactTransferException: Could not transfer artifact org.restlet.jee:org.restlet:pom:2.3.0 from/to Restlet Releases (https://maven.restlet.com/): Received fatal alert: handshake_failure
	at org.sonatype.aether.connector.wagon.WagonRepositoryConnector$4.wrap(WagonRepositoryConnector.java:951)
	at org.sonatype.aether.connector.wagon.WagonRepositoryConnector$4.wrap(WagonRepositoryConnector.java:941)
	at org.sonatype.aether.connector.wagon.WagonRepositoryConnector$GetTask.run(WagonRepositoryConnector.java:669)
	at org.sonatype.aether.util.concurrency.RunnableErrorForwarder$1.run(RunnableErrorForwarder.java:60)
	... 3 more
Caused by: org.apache.maven.wagon.TransferFailedException: Received fatal alert: handshake_failure
	at org.apache.maven.wagon.shared.http4.AbstractHttpClientWagon.fillInputData(AbstractHttpClientWagon.java:799)
	at org.apache.maven.wagon.StreamWagon.getInputStream(StreamWagon.java:116)
	at org.apache.maven.wagon.StreamWagon.getIfNewer(StreamWagon.java:88)
	at org.apache.maven.wagon.StreamWagon.get(StreamWagon.java:61)
	at org.sonatype.aether.connector.wagon.WagonRepositoryConnector$GetTask.run(WagonRepositoryConnector.java:601)
	... 4 more
Caused by: javax.net.ssl.SSLHandshakeException: Received fatal alert: handshake_failure
	at sun.security.ssl.Alerts.getSSLException(Alerts.java:192)
```