### PR TITLE
replace deprecated API use in TestSolrCloudClusterSupport

### DIFF
--- a/src/test/java/com/lucidworks/spark/TestSolrCloudClusterSupport.java
+++ b/src/test/java/com/lucidworks/spark/TestSolrCloudClusterSupport.java
@@ -94,7 +94,9 @@ public class TestSolrCloudClusterSupport {
     cluster = new MiniSolrCloudCluster(1, null /* hostContext */,
             testWorkingDir.toPath(), solrXmlContents, extraServlets, null);
 
-    cloudSolrServer = new CloudSolrClient.Builder().withZkHost(cluster.getZkServer().getZkAddress()).sendUpdatesOnlyToShardLeaders().build();
+    final List<String> zkHosts = Collections.singletonList(cluster.getZkServer().getZkAddress());
+    final Optional<String> zkChroot = Optional.empty();
+    cloudSolrServer = new CloudSolrClient.Builder(zkHosts, zkChroot).sendUpdatesOnlyToShardLeaders().build();
     cloudSolrServer.connect();
 
     assertTrue(!cloudSolrServer.getZkStateReader().getClusterState().getLiveNodes().isEmpty());


### PR DESCRIPTION
The `CloudSolrClient.Builder()` and `CloudSolrClient.Builder.withZkHost(String)` APIs are deprecated as per the https://solr.apache.org/docs/8_4_1/solr-solrj/org/apache/solr/client/solrj/impl/CloudSolrClient.Builder.html documentation.