### PR TITLE
replace deprecated org.apache.spark API use (in examples and tests)

### DIFF
--- a/src/main/java/com/lucidworks/spark/example/ml/MLPipeline.java
+++ b/src/main/java/com/lucidworks/spark/example/ml/MLPipeline.java
@@ -219,7 +219,7 @@ public class MLPipeline implements SparkApp.RDDProcessor {
 
     // compute the false positive rate per label
     System.out.println();
-    System.out.println("F-Measure: "+metrics.fMeasure());
+    System.out.println("Accuracy: "+metrics.accuracy());
     System.out.println("label\tfpr\n");
 
     String[] labels = labelConverter.getLabels();

--- a/src/main/java/com/lucidworks/spark/example/query/KMeansAnomaly.java
+++ b/src/main/java/com/lucidworks/spark/example/query/KMeansAnomaly.java
@@ -99,7 +99,7 @@ public class KMeansAnomaly implements SparkApp.RDDProcessor {
     SolrJavaRDD solrRDD = SolrJavaRDD.get(zkHost, collection, jsc.sc());
     Dataset solrDataWithPivots = SolrQuerySupport.withPivotFields(logEvents, pivotFields, solrRDD.rdd(), false);
     // register this DataFrame so we can execute a SQL query against it for doing sessionization using lag window func
-    solrDataWithPivots.registerTempTable("logs");
+    solrDataWithPivots.createOrReplaceTempView("logs");
 
     // used in SQL below to convert a timestamp into millis since the epoch
     sparkSession.udf().register("ts2ms", new UDF1<Timestamp, Long>() {

--- a/src/main/scala/com/lucidworks/spark/example/ml/MLPipelineScala.scala
+++ b/src/main/scala/com/lucidworks/spark/example/ml/MLPipelineScala.scala
@@ -156,7 +156,7 @@ class MLPipelineScala extends SparkApp.RDDProcessor {
                           |${metrics.confusionMatrix}\n""".stripMargin)
 
     // compute the false positive rate per label
-    println(s"""\nF-Measure: ${metrics.fMeasure}
+    println(s"""\nAccuracy: ${metrics.accuracy}
                           |label\tfpr\n""".stripMargin)
     val labels = labelConverter.getLabels
     for (i <- labels.indices)

--- a/src/test/java/com/lucidworks/spark/SolrRelationTest.java
+++ b/src/test/java/com/lucidworks/spark/SolrRelationTest.java
@@ -238,7 +238,7 @@ public class SolrRelationTest extends RDDProcessorTestBase {
         options.put(SOLR_COLLECTION_PARAM(), testCollection);
 
         Dataset df = sparkSession.read().format("solr").options(options).load();
-        df.registerTempTable("events");
+        df.createOrReplaceTempView("events");
         sparkSession.sql("SELECT * FROM events").take(1);
 
         sparkSession.sql("SELECT `params.title_s` from events").take(2);
@@ -331,7 +331,7 @@ public class SolrRelationTest extends RDDProcessorTestBase {
 
       Dataset df = sparkSession.read().format("solr").options(options).load();
       df.show();
-      df.registerTempTable(testCollection);
+      df.createOrReplaceTempView(testCollection);
       validateSchema(df);
       //df.show();
 

--- a/src/test/java/com/lucidworks/spark/SolrSqlTest.java
+++ b/src/test/java/com/lucidworks/spark/SolrSqlTest.java
@@ -43,7 +43,7 @@ public class SolrSqlTest extends RDDProcessorTestBase {
 
       {
         Dataset eventsim = sparkSession.read().format("solr").options(options).option(SOLR_DOC_VALUES(), "true").load();
-        eventsim.registerTempTable("eventsim");
+        eventsim.createOrReplaceTempView("eventsim");
 
         Dataset records = sparkSession.sql("SELECT * FROM eventsim");
         StructType schema = records.schema();
@@ -66,7 +66,7 @@ public class SolrSqlTest extends RDDProcessorTestBase {
       // Filter using SQL syntax and escape field names
       {
         Dataset eventsim = sparkSession.read().format("solr").options(options).load();
-        eventsim.registerTempTable("eventsim");
+        eventsim.createOrReplaceTempView("eventsim");
 
         Dataset records = sparkSession.sql("SELECT `userId`, `ts` from eventsim WHERE `gender` = 'M'");
         assert records.count() == 567;

--- a/src/test/java/com/lucidworks/spark/util/EventsimUtil.java
+++ b/src/test/java/com/lucidworks/spark/util/EventsimUtil.java
@@ -32,7 +32,7 @@ public class EventsimUtil {
     // Modify the unix timestamp to ISO format for Solr
     log.info("Indexing eventsim documents from file " + datasetPath);
 
-    df.registerTempTable("jdbcDF");
+    df.createOrReplaceTempView("jdbcDF");
     sparkSession.udf().register("ts2iso", new UDF1<Long, Timestamp>() {
       public Timestamp call(Long ts) {
         return asDate(ts);


### PR DESCRIPTION
javadoc links:
* http://spark.apache.org/docs/2.4.5/api/java/org/apache/spark/sql/Dataset.html#registerTempTable-java.lang.String-
* http://spark.apache.org/docs/2.4.5/api/java/org/apache/spark/mllib/evaluation/MulticlassMetrics.html#fMeasure--