### PR TITLE
use LATEST luceneMatchVersion in test/resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <spark.version>2.4.5</spark.version>
-    <solr.version>8.4.1</solr.version>
+    <solr.version>8.4.1</solr.version> <!-- see also luceneMatchVersion in test/resources *solrconfig.xml files -->
     <hadoop.version>2.7.5</hadoop.version>
     <fasterxml.version>2.10.1</fasterxml.version>
     <scala.version>2.11.12</scala.version>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <spark.version>2.4.5</spark.version>
-    <solr.version>8.4.1</solr.version> <!-- see also luceneMatchVersion in test/resources *solrconfig.xml files -->
+    <solr.version>8.4.1</solr.version>
     <hadoop.version>2.7.5</hadoop.version>
     <fasterxml.version>2.10.1</fasterxml.version>
     <scala.version>2.11.12</scala.version>

--- a/src/test/resources/conf/solrconfig.xml
+++ b/src/test/resources/conf/solrconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <config>
-  <luceneMatchVersion>6.4.2</luceneMatchVersion>
+  <luceneMatchVersion>8.4.1</luceneMatchVersion>
   <dataDir>${solr.data.dir:}</dataDir>
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
   <codecFactory class="solr.SchemaCodecFactory"/>

--- a/src/test/resources/conf/solrconfig.xml
+++ b/src/test/resources/conf/solrconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <config>
-  <luceneMatchVersion>8.4.1</luceneMatchVersion>
+  <luceneMatchVersion>LATEST</luceneMatchVersion>
   <dataDir>${solr.data.dir:}</dataDir>
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
   <codecFactory class="solr.SchemaCodecFactory"/>

--- a/src/test/resources/custom-solrconfig.xml
+++ b/src/test/resources/custom-solrconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <config>
-    <luceneMatchVersion>7.5.0</luceneMatchVersion>
+    <luceneMatchVersion>8.4.1</luceneMatchVersion>
     <dataDir>${solr.data.dir:}</dataDir>
     <directoryFactory name="DirectoryFactory" class="solr.RAMDirectoryFactory"/>
     <codecFactory class="solr.SchemaCodecFactory"/>

--- a/src/test/resources/custom-solrconfig.xml
+++ b/src/test/resources/custom-solrconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <config>
-    <luceneMatchVersion>8.4.1</luceneMatchVersion>
+    <luceneMatchVersion>LATEST</luceneMatchVersion>
     <dataDir>${solr.data.dir:}</dataDir>
     <directoryFactory name="DirectoryFactory" class="solr.RAMDirectoryFactory"/>
     <codecFactory class="solr.SchemaCodecFactory"/>


### PR DESCRIPTION
When running the tests locally I noticed warnings in the output e.g.

```
WARN  FieldTypePluginLoader  - TokenizerFactory is using deprecated 6.4.2 emulation. You should at some point declare and reindex to at least 7.0, because 6.x emulation is deprecated and will be removed in 8.0
```

* Increasing the tests' `luceneMatchVersion` version removes the warnings but I don't know if the versions currently in use are used for a specific reason or not?
* The `spark-solr/src/main/resources/embedded/solrconfig.xml` file e.g. https://github.com/lucidworks/spark-solr/blob/v3.7.6/src/main/resources/embedded/solrconfig.xml#L3 uses `<luceneMatchVersion>LATEST</luceneMatchVersion>` and if no specific version is intended or required for the tests then using `LATEST` could be an alternative too.
  * edit: it seems no specific version is required and so I've added a commit to use `LATEST` instead