### PR TITLE
improve retries by adding parameters

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -332,6 +332,30 @@ Usage: `option("batch_size", "10000")`
 
 Default: 500
 
+==== retry_backoff_delay_ms
+
+The `retry_backoff_delay_ms` option, when doing retries is the amount to backoff between retries, in milliseconds.
+
+Usage: `option("retry_backoff_delay_ms", "1000")`
+
+Default: 2500
+
+==== retry_max_delay_ms
+
+The `retry_max_delay_ms` option, when doing retries is the maximum amount of delay for a single backoff, in milliseconds.
+
+Usage: `option("retry_max_delay_ms", "5000")`
+
+Default: 10000
+
+==== retry_max_duration_ms
+
+The `retry_max_duration_ms` option, when doing retries is the maximum duration of a retry attempt, in milliseconds.
+
+Usage: `option("retry_max_duration_ms", "120000")`
+
+Default: 60000
+
 ==== gen_uniq_key
 
 If the documents are missing the unique key (derived from Solr schema), then the `gen_uniq_key` option will generate a unique value for each document before indexing to Solr. Instead of this option, the http://lucene.apache.org/solr/api/solr-core/org/apache/solr/update/processor/UUIDUpdateProcessorFactory.html[UUIDUpdateProcessorFactory] can be used to generate UUID values for documents that are missing the unique key field

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <scala.version>2.11.12</scala.version>
     <scala.binary.version>2.11</scala.binary.version>
     <scoverage.plugin.version>1.1.1</scoverage.plugin.version>
+    <jodah.retry.version>2.4.0</jodah.retry.version>
     <MaxPermSize>128m</MaxPermSize>
   </properties>
   <pluginRepositories>
@@ -513,6 +514,11 @@
           <artifactId>hadoop-hdfs-client</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>net.jodah</groupId>
+      <artifactId>failsafe</artifactId>
+      <version>${jodah.retry.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.solr</groupId>

--- a/src/main/java/com/lucidworks/spark/example/hadoop/HdfsToSolrRDDProcessor.java
+++ b/src/main/java/com/lucidworks/spark/example/hadoop/HdfsToSolrRDDProcessor.java
@@ -1,5 +1,6 @@
 package com.lucidworks.spark.example.hadoop;
 
+import com.lucidworks.spark.util.SolrRequestRetryer;
 import com.lucidworks.spark.util.SolrSupport;
 import com.lucidworks.spark.SparkApp;
 import org.apache.commons.cli.CommandLine;
@@ -79,7 +80,7 @@ public class HdfsToSolrRDDProcessor implements SparkApp.RDDProcessor {
     int numRunners = Integer.parseInt(cli.getOptionValue("numRunners", "2"));
     int pollQueueTime = Integer.parseInt(cli.getOptionValue("pollQueueTime", "20"));
     //SolrSupport.streamDocsIntoSolr(zkHost, collection, "id", pairs, queueSize, numRunners, pollQueueTime);
-    SolrSupport.indexDocs(zkHost, collection, 100, pairs.values().rdd());
+    SolrSupport.indexDocs(zkHost, collection, 100, SolrRequestRetryer.DEFAULT_MAX_BACKOFF_DELAY_MS, SolrRequestRetryer.DEFAULT_MAX_DELAY_MS, SolrRequestRetryer.DEFAULT_MAX_DURATION_MS, pairs.values().rdd());
 
     // send a final commit in case soft auto-commits are not enabled
     CloudSolrClient cloudSolrClient = SolrSupport.getCachedCloudClient(zkHost);

--- a/src/main/java/com/lucidworks/spark/example/hadoop/Logs2SolrRDDProcessor.java
+++ b/src/main/java/com/lucidworks/spark/example/hadoop/Logs2SolrRDDProcessor.java
@@ -1,5 +1,6 @@
 package com.lucidworks.spark.example.hadoop;
 
+import com.lucidworks.spark.util.SolrRequestRetryer;
 import com.lucidworks.spark.util.SolrSupport;
 import com.lucidworks.spark.SparkApp;
 import org.apache.commons.cli.CommandLine;
@@ -68,13 +69,13 @@ public class Logs2SolrRDDProcessor implements SparkApp.RDDProcessor {
               doc.setField("line_t", line);
               batch.add(doc);
               if (batch.size() >= batchSize)
-                SolrSupport.sendBatchToSolr(solrServer, collection, JavaConversions.collectionAsScalaIterable(batch));
+                SolrSupport.sendBatchToSolr(solrServer, SolrRequestRetryer.defaultInstance(), collection, JavaConversions.collectionAsScalaIterable(batch));
 
               if (lineNum % 10000 == 0)
                 log.info("Sent "+lineNum+" docs to Solr from "+path);
             }
             if (!batch.isEmpty())
-              SolrSupport.sendBatchToSolr(solrServer, collection, JavaConversions.collectionAsScalaIterable(batch));
+              SolrSupport.sendBatchToSolr(solrServer, SolrRequestRetryer.defaultInstance(), collection, JavaConversions.collectionAsScalaIterable(batch));
           } catch (Exception exc) {
             log.error("Failed to read '" + path + "' due to: " + exc);
           } finally {

--- a/src/main/java/com/lucidworks/spark/example/streaming/DocumentFilteringStreamProcessor.java
+++ b/src/main/java/com/lucidworks/spark/example/streaming/DocumentFilteringStreamProcessor.java
@@ -101,7 +101,7 @@ public class DocumentFilteringStreamProcessor extends SparkApp.StreamProcessor {
       SolrSupport.filterDocuments(docFilterContext, zkHost, filterCollection, docs.dstream());
 
     // now index the enriched docs into Solr (or do whatever after the matching process runs)
-    SolrSupport.indexDStreamOfDocs(zkHost, collection, batchSize, enriched);
+    SolrSupport.indexDStreamOfDocs(zkHost, collection, batchSize, retryBackoffDelayMs, retryMaxDelayMs, retryMaxDurationMs, enriched);
   }
 
   protected DocFilterContext loadDocFilterContext(JavaStreamingContext jssc, CommandLine cli)

--- a/src/main/java/com/lucidworks/spark/example/streaming/TwitterToSolrStreamProcessor.java
+++ b/src/main/java/com/lucidworks/spark/example/streaming/TwitterToSolrStreamProcessor.java
@@ -69,7 +69,7 @@ public class TwitterToSolrStreamProcessor extends SparkApp.StreamProcessor {
       );
 
       // when ready, send the docs into a SolrCloud cluster
-      SolrSupport.indexDStreamOfDocs(zkHost, collection, batchSize, docs.dstream());
+      SolrSupport.indexDStreamOfDocs(zkHost, collection, batchSize, retryBackoffDelayMs, retryMaxDelayMs, retryMaxDurationMs, docs.dstream());
     }
   }
 

--- a/src/main/java/com/lucidworks/spark/util/SolrRequestRetryer.java
+++ b/src/main/java/com/lucidworks/spark/util/SolrRequestRetryer.java
@@ -44,7 +44,7 @@ public class SolrRequestRetryer {
                         ConnectException.class,
                         NoHttpResponseException.class,
                         SocketException.class))
-                .onRetry(retry -> log.warn("Experienced an error when doing a SolrRequest. Performing a retry: " + retry))));
+                .onRetry(retry -> log.error("Experienced an error when doing a SolrRequest. Performing a retry: " + retry))));
     }
 
     public SolrRequestRetryer(RetryPolicy<NamedList<Object>> retryPolicy) {

--- a/src/main/java/com/lucidworks/spark/util/SolrRequestRetryer.java
+++ b/src/main/java/com/lucidworks/spark/util/SolrRequestRetryer.java
@@ -1,0 +1,57 @@
+package com.lucidworks.spark.util;
+
+import com.google.common.collect.Maps;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import org.apache.http.NoHttpResponseException;
+import org.apache.log4j.Logger;
+import org.apache.solr.client.solrj.SolrClient;
+import org.apache.solr.client.solrj.SolrRequest;
+import org.apache.solr.client.solrj.SolrServerException;
+import org.apache.solr.common.SolrException;
+import org.apache.solr.common.util.NamedList;
+
+import java.net.ConnectException;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Map;
+
+public class SolrRequestRetryer {
+    public static final long DEFAULT_MAX_DURATION_MS = 60000L;
+    public static final long DEFAULT_MAX_DELAY_MS = 10000L;
+    public static final long DEFAULT_MAX_BACKOFF_DELAY_MS = 2500L;
+    public static Logger log = Logger.getLogger(SolrRequestRetryer.class);
+
+    private static final Map<String, SolrRequestRetryer> RETRY_POLICY_MAP = Maps.newConcurrentMap();
+
+    private final RetryPolicy<NamedList<Object>> retryPolicy;
+    private boolean enabled = true;
+
+    public static SolrRequestRetryer defaultInstance() {
+        return instance(DEFAULT_MAX_BACKOFF_DELAY_MS, DEFAULT_MAX_DELAY_MS, DEFAULT_MAX_DURATION_MS);
+    }
+
+    public static SolrRequestRetryer instance(long backoffDelayMs, long maxDelayMs, long maxDurationMs) {
+        return RETRY_POLICY_MAP.computeIfAbsent(String.format("%d-%d-%d", backoffDelayMs, maxDelayMs, maxDurationMs), key -> new SolrRequestRetryer(new RetryPolicy<NamedList<Object>>()
+                .withBackoff(backoffDelayMs, maxDelayMs, ChronoUnit.MILLIS)
+                .withMaxDuration(Duration.ofMillis(maxDurationMs))
+                .handle(Arrays.asList(SolrServerException.class,
+                        SocketTimeoutException.class,
+                        SolrException.class,
+                        ConnectException.class,
+                        NoHttpResponseException.class,
+                        SocketException.class))
+                .onRetry(retry -> log.warn("Experienced an error when doing a SolrRequest. Performing a retry: " + retry))));
+    }
+
+    public SolrRequestRetryer(RetryPolicy<NamedList<Object>> retryPolicy) {
+        this.retryPolicy = retryPolicy;
+    }
+
+    public NamedList<Object> request(SolrClient solrClient, SolrRequest request) {
+        return Failsafe.with(retryPolicy).get(() -> solrClient.request(request));
+    }
+}

--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -108,6 +108,15 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
   def batchSize: Option[Int] =
     if (config.get(BATCH_SIZE).isDefined) Some(config(BATCH_SIZE).toInt) else None
 
+  def retryBackoffDelayMs: Option[Long] =
+    if (config.get(RETRY_BACKOFF_DELAY_MS).isDefined) Some(config(RETRY_BACKOFF_DELAY_MS).toLong) else None
+
+  def retryMaxDelayMs: Option[Long] =
+    if (config.get(RETRY_MAX_DELAY_MS).isDefined) Some(config(RETRY_MAX_DELAY_MS).toLong) else None
+
+  def retryMaxDurationMs: Option[Long] =
+    if (config.get(RETRY_MAX_DURATION_MS).isDefined) Some(config(RETRY_MAX_DURATION_MS).toLong) else None
+
   def useCursorMarks: Option[Boolean] =
     if (config.get(USE_CURSOR_MARKS).isDefined) Some(config(USE_CURSOR_MARKS).toBoolean) else None
 
@@ -283,6 +292,15 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
     }
     if (batchSize.isDefined) {
       sb ++= s", ${BATCH_SIZE}=${batchSize.get}"
+    }
+    if (retryBackoffDelayMs.isDefined) {
+      sb ++= s", ${RETRY_BACKOFF_DELAY_MS}=${retryBackoffDelayMs.get}"
+    }
+    if (retryMaxDelayMs.isDefined) {
+      sb ++= s", ${RETRY_MAX_DELAY_MS}=${retryMaxDelayMs.get}"
+    }
+    if (retryMaxDurationMs.isDefined) {
+      sb ++= s", ${RETRY_MAX_DURATION_MS}=${retryMaxDurationMs.get}"
     }
     if (getChildDocFieldName.isDefined) {
       sb ++= s", ${CHILD_DOC_FIELDNAME}=${getChildDocFieldName.get}"

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -670,6 +670,9 @@ class SolrRelation(
     }
 
     val batchSize: Int = if (conf.batchSize.isDefined) conf.batchSize.get else 1000
+    val retryBackoffDelayMs: Long = if (conf.retryBackoffDelayMs.isDefined) conf.retryBackoffDelayMs.get else 2500
+    val retryMaxDelayMs: Long = if (conf.retryMaxDelayMs.isDefined) conf.retryMaxDelayMs.get else 10000
+    val retryMaxDurationMs: Long = if (conf.retryMaxDurationMs.isDefined) conf.retryMaxDurationMs.get else 60000
 
     // Convert RDD of rows in to SolrInputDocuments
     val uk = SolrQuerySupport.getUniqueKey(zkHost, collectionId)
@@ -680,7 +683,7 @@ class SolrRelation(
     val accName = if (conf.getAccumulatorName.isDefined) conf.getAccumulatorName.get else "Records Written"
     sparkSession.sparkContext.register(acc, accName)
     SparkSolrAccumulatorContext.add(accName, acc.id)
-    SolrSupport.indexDocs(zkHost, collectionId, batchSize, docs, conf.commitWithin, Some(acc))
+    SolrSupport.indexDocs(zkHost, collectionId, batchSize, retryBackoffDelayMs, retryMaxDelayMs, retryMaxDurationMs, docs, conf.commitWithin, Some(acc))
     logger.info("Written {} documents to Solr collection {}", acc.value, collectionId)
   }
 

--- a/src/main/scala/com/lucidworks/spark/SolrStreamWriter.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrStreamWriter.scala
@@ -1,6 +1,6 @@
 package com.lucidworks.spark
 
-import com.lucidworks.spark.util.{SolrQuerySupport, SolrSupport}
+import com.lucidworks.spark.util.{SolrQuerySupport, SolrRequestRetryer, SolrSupport}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.execution.streaming.Sink
 import org.apache.spark.sql.streaming.OutputMode
@@ -68,7 +68,7 @@ class SolrStreamWriter(
 
         val solrDocs = rows.toStream.map(row => SolrRelation.convertRowToSolrInputDocument(row, solrConf, uniqueKey))
         acc.add(solrDocs.length.toLong)
-        SolrSupport.sendBatchToSolrWithRetry(zkhost, solrClient, collection, solrDocs, solrConf.commitWithin)
+        SolrSupport.sendBatchToSolrWithRetry(zkhost, solrClient, SolrRequestRetryer.defaultInstance(), collection, solrDocs, solrConf.commitWithin)
         logger.info(s"Written ${solrDocs.length} documents to Solr collection $collection from batch $batchId")
         latestBatchId = batchId
       }

--- a/src/main/scala/com/lucidworks/spark/example/ml/NewsgroupsIndexer.scala
+++ b/src/main/scala/com/lucidworks/spark/example/ml/NewsgroupsIndexer.scala
@@ -2,9 +2,8 @@ package com.lucidworks.spark.example.ml
 
 import java.net.URI
 import java.util.Locale
-
 import com.lucidworks.spark.{LazyLogging, SparkApp}
-import com.lucidworks.spark.util.SolrSupport
+import com.lucidworks.spark.util.{SolrRequestRetryer, SolrSupport}
 import org.apache.commons.cli.CommandLine
 import org.apache.commons.cli.Option.{builder => OptionBuilder}
 import org.apache.solr.common.SolrInputDocument
@@ -101,7 +100,7 @@ class NewsgroupsIndexer extends SparkApp.RDDProcessor with LazyLogging {
       val solrServer = SolrSupport.getCachedCloudClient(zkHost)
       val batch = ListBuffer.empty[SolrInputDocument]
       def sendBatch(): Unit = {
-        SolrSupport.sendBatchToSolr(solrServer, collection, batch.toList)
+        SolrSupport.sendBatchToSolr(solrServer, SolrRequestRetryer.defaultInstance(), collection, batch.toList)
         numDocs += batch.size
         logger.info(s"Sent $numDocs docs to Solr from $path")
         batch.clear()

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -26,6 +26,9 @@ object ConfigurationConstants {
   // Index params
   val SOFT_AUTO_COMMIT_SECS: String = "soft_commit_secs"
   val BATCH_SIZE: String = "batch_size"
+  val RETRY_BACKOFF_DELAY_MS: String = "retry_backoff_delay_ms"
+  val RETRY_MAX_DELAY_MS: String = "retry_max_delay_ms"
+  val RETRY_MAX_DURATION_MS: String = "retry_max_duration_ms"
   val GENERATE_UNIQUE_KEY: String = "gen_uniq_key"
   val GENERATE_UNIQUE_CHILD_KEY: String = "gen_uniq_child_key"
   val COMMIT_WITHIN_MILLI_SECS: String = "commit_within"

--- a/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrSupport.scala
@@ -265,8 +265,11 @@ object SolrSupport extends LazyLogging {
       zkHost: String,
       collection: String,
       batchSize: Int,
+      retryBackoffDelayMs: Long,
+      retryMaxDelayMs: Long,
+      retryMaxDurationMs: Long,
       docs: DStream[SolrInputDocument]): Unit =
-    docs.foreachRDD(rdd => indexDocs(zkHost, collection, batchSize, rdd))
+    docs.foreachRDD(rdd => indexDocs(zkHost, collection, batchSize, retryBackoffDelayMs, retryMaxDelayMs, retryMaxDurationMs, rdd))
 
   def sendDStreamOfDocsToFusion(
       fusionUrl: String,
@@ -309,18 +312,25 @@ object SolrSupport extends LazyLogging {
       zkHost: String,
       collection: String,
       batchSize: Int,
-      rdd: RDD[SolrInputDocument]): Unit = indexDocs(zkHost, collection, batchSize, rdd, None)
+      retryBackoffDelayMs: Long,
+      retryMaxDelayMs: Long,
+      retryMaxDurationMs: Long,
+      rdd: RDD[SolrInputDocument]): Unit = indexDocs(zkHost, collection, batchSize, retryBackoffDelayMs, retryMaxDelayMs, retryMaxDurationMs, rdd, None)
 
   def indexDocs(
       zkHost: String,
       collection: String,
       batchSize: Int,
+      retryBackoffDelayMs: Long,
+      retryMaxDelayMs: Long,
+      retryMaxDurationMs: Long,
       rdd: RDD[SolrInputDocument],
       commitWithin: Option[Int],
       accumulator: Option[SparkSolrAccumulator] = None): Unit = {
     //TODO: Return success or false by boolean ?
     rdd.foreachPartition(solrInputDocumentIterator => {
       val solrClient = getCachedCloudClient(zkHost)
+      val solrRequestRetryer = SolrRequestRetryer.instance(retryBackoffDelayMs, retryMaxDelayMs, retryMaxDurationMs)
       val batch = new ArrayBuffer[SolrInputDocument]()
       var numDocs: Long = 0
       while (solrInputDocumentIterator.hasNext) {
@@ -330,7 +340,7 @@ object SolrSupport extends LazyLogging {
           numDocs += batch.length
           if (accumulator.isDefined)
             accumulator.get.add(batch.length.toLong)
-          sendBatchToSolrWithRetry(zkHost, solrClient, collection, batch, commitWithin)
+          sendBatchToSolrWithRetry(zkHost, solrClient, solrRequestRetryer, collection, batch, commitWithin)
           batch.clear
         }
       }
@@ -338,7 +348,7 @@ object SolrSupport extends LazyLogging {
         numDocs += batch.length
         if (accumulator.isDefined)
           accumulator.get.add(batch.length.toLong)
-        sendBatchToSolrWithRetry(zkHost, solrClient, collection, batch, commitWithin)
+        sendBatchToSolrWithRetry(zkHost, solrClient, solrRequestRetryer, collection, batch, commitWithin)
         batch.clear
       }
     })
@@ -347,11 +357,12 @@ object SolrSupport extends LazyLogging {
   def sendBatchToSolrWithRetry(
       zkHost: String,
       solrClient: SolrClient,
+      solrRequestRetryer: SolrRequestRetryer,
       collection: String,
       batch: Iterable[SolrInputDocument],
       commitWithin: Option[Int]): Unit = {
     try {
-      sendBatchToSolr(solrClient, collection, batch, commitWithin)
+      sendBatchToSolr(solrClient, solrRequestRetryer, collection, batch, commitWithin)
     } catch {
       // Reset the cache when SessionExpiredException is thrown. Plus side is that the job won't fail
       case e : Exception =>
@@ -360,16 +371,17 @@ object SolrSupport extends LazyLogging {
             logger.info("Got an exception with message '" + e1.getMessage +  "'.  Resetting the cached solrClient")
             CacheCloudSolrClient.cache.invalidate(CloudClientParams(zkHost))
             val newClient = SolrSupport.getCachedCloudClient(zkHost)
-            sendBatchToSolr(newClient, collection, batch, commitWithin)
+            sendBatchToSolr(newClient, solrRequestRetryer, collection, batch, commitWithin)
         }
     }
   }
 
-  def sendBatchToSolr(solrClient: SolrClient, collection: String, batch: Iterable[SolrInputDocument]): Unit =
-    sendBatchToSolr(solrClient, collection, batch, None)
+  def sendBatchToSolr(solrClient: SolrClient, solrRequestRetryer: SolrRequestRetryer, collection: String, batch: Iterable[SolrInputDocument]): Unit =
+    sendBatchToSolr(solrClient, solrRequestRetryer, collection, batch, None)
 
   def sendBatchToSolr(
       solrClient: SolrClient,
+      solrRequestRetryer: SolrRequestRetryer,
       collection: String,
       batch: Iterable[SolrInputDocument],
       commitWithin: Option[Int]): Unit = {
@@ -386,37 +398,16 @@ object SolrSupport extends LazyLogging {
     req.add(asJavaCollection(batch))
 
     try {
-      solrClient.request(req)
+      solrRequestRetryer.request(solrClient, req)
       val timeTaken = (System.currentTimeMillis() - initialTime)/1000.0
       logger.info("Took '" + timeTaken + "' secs to index '" + batch.size + "' documents")
     } catch {
       case e: Exception =>
-        if (shouldRetry(e)) {
-          logger.error("Send batch to collection " + collection + " failed due to " + e + " ; will retry ...")
-          try {
-            Thread.sleep(2000)
-          } catch {
-            case ie: InterruptedException => Thread.interrupted()
-          }
-
-          try {
-            solrClient.request(req)
-          } catch {
-            case ex: Exception =>
-              logger.error("Send batch to collection " + collection + " failed due to: " + e, e)
-              ex match {
-                case re: RuntimeException => throw re
-                case e: Exception => throw new RuntimeException(e)
-              }
-          }
-        } else {
-          logger.error("Send batch to collection " + collection + " failed due to: " + e, e)
-          e match {
-            case re: RuntimeException => throw re
-            case ex: Exception => throw new RuntimeException(ex)
-          }
+        logger.error("Send batch to collection " + collection + " failed due to: " + e, e)
+        e match {
+          case re: RuntimeException => throw re
+          case ex: Exception => throw new RuntimeException(ex)
         }
-
     }
 
   }

--- a/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
+++ b/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
@@ -1,6 +1,7 @@
 package com.lucidworks.spark;
 
 import com.lucidworks.spark.rdd.SolrJavaRDD;
+import com.lucidworks.spark.util.SolrRequestRetryer;
 import com.lucidworks.spark.util.SolrSupport;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
@@ -130,7 +131,7 @@ public class RDDProcessorTestBase extends TestSolrCloudClusterSupport implements
         return doc;
       }
     });
-    SolrSupport.indexDocs(zkHost, collection, 1000, docs.rdd());
+    SolrSupport.indexDocs(zkHost, collection, 1000, SolrRequestRetryer.DEFAULT_MAX_BACKOFF_DELAY_MS, SolrRequestRetryer.DEFAULT_MAX_DELAY_MS, SolrRequestRetryer.DEFAULT_MAX_DURATION_MS, docs.rdd());
     return inputDocs.length;
   }
 }

--- a/src/test/java/com/lucidworks/spark/example/streaming/BasicIndexingTest.java
+++ b/src/test/java/com/lucidworks/spark/example/streaming/BasicIndexingTest.java
@@ -6,6 +6,7 @@ import java.util.concurrent.LinkedBlockingDeque;
 
 import com.lucidworks.spark.StreamProcessorTestBase;
 import com.lucidworks.spark.rdd.SolrJavaRDD;
+import com.lucidworks.spark.util.SolrRequestRetryer;
 import com.lucidworks.spark.util.SolrSupport;
 import org.apache.solr.client.solrj.SolrQuery;
 import org.apache.solr.common.SolrDocument;
@@ -63,7 +64,7 @@ public class BasicIndexingTest extends StreamProcessorTestBase {
 
     // Send to Solr
     String zkHost = cluster.getZkServer().getZkAddress();
-    SolrSupport.indexDStreamOfDocs(zkHost, testCollection, 1, docs.dstream());
+    SolrSupport.indexDStreamOfDocs(zkHost, testCollection, 1, SolrRequestRetryer.DEFAULT_MAX_BACKOFF_DELAY_MS, SolrRequestRetryer.DEFAULT_MAX_DELAY_MS, SolrRequestRetryer.DEFAULT_MAX_DURATION_MS, docs.dstream());
 
     // Actually start processing the stream here ...
     jssc.start();

--- a/src/test/scala/com/lucidworks/spark/TestFramework.scala
+++ b/src/test/scala/com/lucidworks/spark/TestFramework.scala
@@ -179,7 +179,7 @@ object MovieLensUtil {
       .limit(10000)
       .write
       .format("solr")
-      .options(Map("zkhost" -> zkhost, "collection" -> s"movielens_ratings_$uuid", "batch_size" -> "10000"))
+      .options(Map("zkhost" -> zkhost, "collection" -> s"movielens_ratings_$uuid", "batch_size" -> "10000", "retry_backoff_delay_ms" -> "2000", "retry_max_delay_ms" -> "5000", "retry_max_duration_ms" -> "30000"))
       .save
   }
 }


### PR DESCRIPTION
# New retry parameters:

==== retry_backoff_delay_ms

The `retry_backoff_delay_ms` option, when doing retries is the amount to backoff between retries, in milliseconds.

Usage: `option("retry_backoff_delay_ms", "1000")`

Default: 2500

==== retry_max_delay_ms

The `retry_max_delay_ms` option, when doing retries is the maximum amount of delay for a single backoff, in milliseconds.

Usage: `option("retry_max_delay_ms", "5000")`

Default: 10000

==== retry_max_duration_ms

The `retry_max_duration_ms` option, when doing retries is the maximum duration of a retry attempt, in milliseconds.

Usage: `option("retry_max_duration_ms", "120000")`

Default: 60000