### PR TITLE
3.9.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
-    <spark.version>2.4.5</spark.version>
+    <spark.version>2.4.7</spark.version>
     <solr.version>8.4.1</solr.version>
     <hadoop.version>2.7.5</hadoop.version>
     <fasterxml.version>2.10.1</fasterxml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.lucidworks.spark</groupId>
   <artifactId>spark-solr</artifactId>
-  <version>3.9.0</version>
+  <version>3.10.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>spark-solr</name>
   <description>Tools for reading data from Spark into Solr</description>

--- a/pom.xml
+++ b/pom.xml
@@ -473,7 +473,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.5</version>
+      <version>2.7</version>
     </dependency>
     <dependency>
       <groupId>org.apache.solr</groupId>
@@ -599,7 +599,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.lucidworks.spark</groupId>
   <artifactId>spark-solr</artifactId>
-  <version>3.9.0-SNAPSHOT</version>
+  <version>3.9.0</version>
   <packaging>jar</packaging>
   <name>spark-solr</name>
   <description>Tools for reading data from Spark into Solr</description>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.8</java.version>
     <spark.version>2.4.7</spark.version>
-    <solr.version>8.4.1</solr.version>
+    <solr.version>8.8.2</solr.version>
     <hadoop.version>2.7.5</hadoop.version>
     <fasterxml.version>2.10.1</fasterxml.version>
     <scala.version>2.11.12</scala.version>

--- a/src/main/java/com/lucidworks/spark/BatchSizeType.java
+++ b/src/main/java/com/lucidworks/spark/BatchSizeType.java
@@ -1,0 +1,11 @@
+package com.lucidworks.spark;
+
+/**
+ * Specifices what type of Solr batch you are using.
+ * A) based on the number of documents in the batch.
+ * Or B) based on the number of bytes in the batch.
+ */
+public enum BatchSizeType {
+    NUM_DOCS,
+    NUM_BYTES
+}

--- a/src/main/java/com/lucidworks/spark/SparkApp.java
+++ b/src/main/java/com/lucidworks/spark/SparkApp.java
@@ -65,12 +65,14 @@ public class SparkApp implements Serializable {
     protected String zkHost;
     protected String collection;
     protected int batchSize;
+    protected BatchSizeType batchSizeType;
     
     public int run(SparkConf conf, CommandLine cli) throws Exception {
 
       this.zkHost = cli.getOptionValue("zkHost", "localhost:9983");
       this.collection = cli.getOptionValue("collection", "collection1");
       this.batchSize = Integer.parseInt(cli.getOptionValue("batchSize", "10"));
+      this.batchSizeType = BatchSizeType.valueOf(cli.getOptionValue("batchSizeType", "NUM_DOCS"));
 
       // Create a local StreamingContext with two working thread and batch interval
       int batchIntervalSecs = Integer.parseInt(cli.getOptionValue("batchInterval", "1"));

--- a/src/main/java/com/lucidworks/spark/example/hadoop/HdfsToSolrRDDProcessor.java
+++ b/src/main/java/com/lucidworks/spark/example/hadoop/HdfsToSolrRDDProcessor.java
@@ -1,5 +1,6 @@
 package com.lucidworks.spark.example.hadoop;
 
+import com.lucidworks.spark.BatchSizeType;
 import com.lucidworks.spark.util.SolrSupport;
 import com.lucidworks.spark.SparkApp;
 import org.apache.commons.cli.CommandLine;
@@ -79,7 +80,7 @@ public class HdfsToSolrRDDProcessor implements SparkApp.RDDProcessor {
     int numRunners = Integer.parseInt(cli.getOptionValue("numRunners", "2"));
     int pollQueueTime = Integer.parseInt(cli.getOptionValue("pollQueueTime", "20"));
     //SolrSupport.streamDocsIntoSolr(zkHost, collection, "id", pairs, queueSize, numRunners, pollQueueTime);
-    SolrSupport.indexDocs(zkHost, collection, 100, pairs.values().rdd());
+    SolrSupport.indexDocs(zkHost, collection, 100, BatchSizeType.NUM_DOCS, pairs.values().rdd());
 
     // send a final commit in case soft auto-commits are not enabled
     CloudSolrClient cloudSolrClient = SolrSupport.getCachedCloudClient(zkHost);

--- a/src/main/java/com/lucidworks/spark/example/ml/MLPipeline.java
+++ b/src/main/java/com/lucidworks/spark/example/ml/MLPipeline.java
@@ -219,7 +219,7 @@ public class MLPipeline implements SparkApp.RDDProcessor {
 
     // compute the false positive rate per label
     System.out.println();
-    System.out.println("F-Measure: "+metrics.fMeasure());
+    System.out.println("Accuracy: "+metrics.accuracy());
     System.out.println("label\tfpr\n");
 
     String[] labels = labelConverter.getLabels();

--- a/src/main/java/com/lucidworks/spark/example/query/KMeansAnomaly.java
+++ b/src/main/java/com/lucidworks/spark/example/query/KMeansAnomaly.java
@@ -99,7 +99,7 @@ public class KMeansAnomaly implements SparkApp.RDDProcessor {
     SolrJavaRDD solrRDD = SolrJavaRDD.get(zkHost, collection, jsc.sc());
     Dataset solrDataWithPivots = SolrQuerySupport.withPivotFields(logEvents, pivotFields, solrRDD.rdd(), false);
     // register this DataFrame so we can execute a SQL query against it for doing sessionization using lag window func
-    solrDataWithPivots.registerTempTable("logs");
+    solrDataWithPivots.createOrReplaceTempView("logs");
 
     // used in SQL below to convert a timestamp into millis since the epoch
     sparkSession.udf().register("ts2ms", new UDF1<Timestamp, Long>() {

--- a/src/main/java/com/lucidworks/spark/example/streaming/DocumentFilteringStreamProcessor.java
+++ b/src/main/java/com/lucidworks/spark/example/streaming/DocumentFilteringStreamProcessor.java
@@ -101,7 +101,7 @@ public class DocumentFilteringStreamProcessor extends SparkApp.StreamProcessor {
       SolrSupport.filterDocuments(docFilterContext, zkHost, filterCollection, docs.dstream());
 
     // now index the enriched docs into Solr (or do whatever after the matching process runs)
-    SolrSupport.indexDStreamOfDocs(zkHost, collection, batchSize, enriched);
+    SolrSupport.indexDStreamOfDocs(zkHost, collection, batchSize, batchSizeType, enriched);
   }
 
   protected DocFilterContext loadDocFilterContext(JavaStreamingContext jssc, CommandLine cli)

--- a/src/main/java/com/lucidworks/spark/example/streaming/TwitterToSolrStreamProcessor.java
+++ b/src/main/java/com/lucidworks/spark/example/streaming/TwitterToSolrStreamProcessor.java
@@ -69,7 +69,7 @@ public class TwitterToSolrStreamProcessor extends SparkApp.StreamProcessor {
       );
 
       // when ready, send the docs into a SolrCloud cluster
-      SolrSupport.indexDStreamOfDocs(zkHost, collection, batchSize, docs.dstream());
+      SolrSupport.indexDStreamOfDocs(zkHost, collection, batchSize, batchSizeType, docs.dstream());
     }
   }
 

--- a/src/main/java/com/lucidworks/spark/util/EmbeddedSolrServerFactory.java
+++ b/src/main/java/com/lucidworks/spark/util/EmbeddedSolrServerFactory.java
@@ -92,9 +92,7 @@ public class EmbeddedSolrServerFactory implements Serializable {
     log.info(String.format("Attempting to bootstrap EmbeddedSolrServer instance in dir: %s",
       instanceDir.getAbsolutePath()));
 
-    SolrResourceLoader solrResourceLoader =
-      new SolrResourceLoader(solrHomeDir.toPath());
-    CoreContainer coreContainer = new CoreContainer(solrResourceLoader);
+    CoreContainer coreContainer = new CoreContainer(solrHomeDir.toPath(), null);
     coreContainer.load();
 
     SolrCore core = coreContainer.create(coreName, instanceDir.toPath(), Collections.<String, String>emptyMap(), false);

--- a/src/main/java/com/lucidworks/spark/util/ObjectSizeCalculator.java
+++ b/src/main/java/com/lucidworks/spark/util/ObjectSizeCalculator.java
@@ -1,0 +1,414 @@
+package com.lucidworks.spark.util;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryPoolMXBean;
+import java.lang.reflect.Array;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Sets;
+
+/**
+ * Contains utility methods for calculating the memory usage of objects. It
+ * only works on the HotSpot JVM, and infers the actual memory layout (32 bit
+ * vs. 64 bit word size, compressed object pointers vs. uncompressed) from
+ * best available indicators. It can reliably detect a 32 bit vs. 64 bit JVM.
+ * It can only make an educated guess at whether compressed OOPs are used,
+ * though; specifically, it knows what the JVM's default choice of OOP
+ * compression would be based on HotSpot version and maximum heap sizes, but if
+ * the choice is explicitly overridden with the <tt>-XX:{+|-}UseCompressedOops</tt> command line
+ * switch, it can not detect
+ * this fact and will report incorrect sizes, as it will presume the default JVM
+ * behavior.
+ *
+ * @author Attila Szegedi
+ */
+public class ObjectSizeCalculator {
+
+  /**
+   * Describes constant memory overheads for various constructs in a JVM implementation.
+   */
+  public interface MemoryLayoutSpecification {
+
+    /**
+     * Returns the fixed overhead of an array of any type or length in this JVM.
+     *
+     * @return the fixed overhead of an array.
+     */
+    int getArrayHeaderSize();
+
+    /**
+     * Returns the fixed overhead of for any {@link Object} subclass in this JVM.
+     *
+     * @return the fixed overhead of any object.
+     */
+    int getObjectHeaderSize();
+
+    /**
+     * Returns the quantum field size for a field owned by an object in this JVM.
+     *
+     * @return the quantum field size for an object.
+     */
+    int getObjectPadding();
+
+    /**
+     * Returns the fixed size of an object reference in this JVM.
+     *
+     * @return the size of all object references.
+     */
+    int getReferenceSize();
+
+    /**
+     * Returns the quantum field size for a field owned by one of an object's ancestor superclasses
+     * in this JVM.
+     *
+     * @return the quantum field size for a superclass field.
+     */
+    int getSuperclassFieldPadding();
+  }
+
+  private static class CurrentLayout {
+    private static final MemoryLayoutSpecification SPEC =
+        getEffectiveMemoryLayoutSpecification();
+  }
+
+  /**
+   * Given an object, returns the total allocated size, in bytes, of the object
+   * and all other objects reachable from it.  Attempts to to detect the current JVM memory layout,
+   * but may fail with {@link UnsupportedOperationException};
+   *
+   * @param obj the object; can be null. Passing in a {@link java.lang.Class} object doesn't do
+   *          anything special, it measures the size of all objects
+   *          reachable through it (which will include its class loader, and by
+   *          extension, all other Class objects loaded by
+   *          the same loader, and all the parent class loaders). It doesn't provide the
+   *          size of the static fields in the JVM class that the Class object
+   *          represents.
+   * @return the total allocated size of the object and all other objects it
+   *         retains.
+   * @throws UnsupportedOperationException if the current vm memory layout cannot be detected.
+   */
+  public static long getObjectSize(Object obj) throws UnsupportedOperationException {
+    return obj == null ? 0 : new ObjectSizeCalculator(CurrentLayout.SPEC).calculateObjectSize(obj);
+  }
+
+  // Fixed object header size for arrays.
+  private final int arrayHeaderSize;
+  // Fixed object header size for non-array objects.
+  private final int objectHeaderSize;
+  // Padding for the object size - if the object size is not an exact multiple
+  // of this, it is padded to the next multiple.
+  private final int objectPadding;
+  // Size of reference (pointer) fields.
+  private final int referenceSize;
+  // Padding for the fields of superclass before fields of subclasses are
+  // added.
+  private final int superclassFieldPadding;
+
+  private final LoadingCache<Class<?>, ClassSizeInfo> classSizeInfos =
+      CacheBuilder.newBuilder().build(new CacheLoader<Class<?>, ClassSizeInfo>() {
+        public ClassSizeInfo load(Class<?> clazz) {
+          return new ClassSizeInfo(clazz);
+        }
+      });
+
+
+  private final Set<Object> alreadyVisited = Sets.newIdentityHashSet();
+  private final Deque<Object> pending = new ArrayDeque<Object>(16 * 1024);
+  private long size;
+
+  /**
+   * Creates an object size calculator that can calculate object sizes for a given
+   * {@code memoryLayoutSpecification}.
+   *
+   * @param memoryLayoutSpecification a description of the JVM memory layout.
+   */
+  public ObjectSizeCalculator(MemoryLayoutSpecification memoryLayoutSpecification) {
+    Preconditions.checkNotNull(memoryLayoutSpecification);
+    arrayHeaderSize = memoryLayoutSpecification.getArrayHeaderSize();
+    objectHeaderSize = memoryLayoutSpecification.getObjectHeaderSize();
+    objectPadding = memoryLayoutSpecification.getObjectPadding();
+    referenceSize = memoryLayoutSpecification.getReferenceSize();
+    superclassFieldPadding = memoryLayoutSpecification.getSuperclassFieldPadding();
+  }
+
+  /**
+   * Given an object, returns the total allocated size, in bytes, of the object
+   * and all other objects reachable from it.
+   *
+   * @param obj the object; can be null. Passing in a {@link java.lang.Class} object doesn't do
+   *          anything special, it measures the size of all objects
+   *          reachable through it (which will include its class loader, and by
+   *          extension, all other Class objects loaded by
+   *          the same loader, and all the parent class loaders). It doesn't provide the
+   *          size of the static fields in the JVM class that the Class object
+   *          represents.
+   * @return the total allocated size of the object and all other objects it
+   *         retains.
+   */
+  public synchronized long calculateObjectSize(Object obj) {
+    // Breadth-first traversal instead of naive depth-first with recursive
+    // implementation, so we don't blow the stack traversing long linked lists.
+    try {
+      for (;;) {
+        visit(obj);
+        if (pending.isEmpty()) {
+          return size;
+        }
+        obj = pending.removeFirst();
+      }
+    } finally {
+      alreadyVisited.clear();
+      pending.clear();
+      size = 0;
+    }
+  }
+
+  private void visit(Object obj) {
+    if (alreadyVisited.contains(obj)) {
+      return;
+    }
+    final Class<?> clazz = obj.getClass();
+    if (clazz == ArrayElementsVisitor.class) {
+      ((ArrayElementsVisitor) obj).visit(this);
+    } else {
+      alreadyVisited.add(obj);
+      if (clazz.isArray()) {
+        visitArray(obj);
+      } else {
+        classSizeInfos.getUnchecked(clazz).visit(obj, this);
+      }
+    }
+  }
+
+  private void visitArray(Object array) {
+    final Class<?> componentType = array.getClass().getComponentType();
+    final int length = Array.getLength(array);
+    if (componentType.isPrimitive()) {
+      increaseByArraySize(length, getPrimitiveFieldSize(componentType));
+    } else {
+      increaseByArraySize(length, referenceSize);
+      // If we didn't use an ArrayElementsVisitor, we would be enqueueing every
+      // element of the array here instead. For large arrays, it would
+      // tremendously enlarge the queue. In essence, we're compressing it into
+      // a small command object instead. This is different than immediately
+      // visiting the elements, as their visiting is scheduled for the end of
+      // the current queue.
+      switch (length) {
+        case 0: {
+          break;
+        }
+        case 1: {
+          enqueue(Array.get(array, 0));
+          break;
+        }
+        default: {
+          enqueue(new ArrayElementsVisitor((Object[]) array));
+        }
+      }
+    }
+  }
+
+  private void increaseByArraySize(int length, long elementSize) {
+    increaseSize(roundTo(arrayHeaderSize + length * elementSize, objectPadding));
+  }
+
+  private static class ArrayElementsVisitor {
+    private final Object[] array;
+
+    ArrayElementsVisitor(Object[] array) {
+      this.array = array;
+    }
+
+    public void visit(ObjectSizeCalculator calc) {
+      for (Object elem : array) {
+        if (elem != null) {
+          calc.visit(elem);
+        }
+      }
+    }
+  }
+
+  void enqueue(Object obj) {
+    if (obj != null) {
+      pending.addLast(obj);
+    }
+  }
+
+  void increaseSize(long objectSize) {
+    size += objectSize;
+  }
+
+  @VisibleForTesting
+  static long roundTo(long x, int multiple) {
+    return ((x + multiple - 1) / multiple) * multiple;
+  }
+
+  private class ClassSizeInfo {
+    // Padded fields + header size
+    private final long objectSize;
+    // Only the fields size - used to calculate the subclasses' memory
+    // footprint.
+    private final long fieldsSize;
+    private final Field[] referenceFields;
+
+    public ClassSizeInfo(Class<?> clazz) {
+      long fieldsSize = 0;
+      final List<Field> referenceFields = new LinkedList<Field>();
+      for (Field f : clazz.getDeclaredFields()) {
+        if (Modifier.isStatic(f.getModifiers())) {
+          continue;
+        }
+        final Class<?> type = f.getType();
+        if (type.isPrimitive()) {
+          fieldsSize += getPrimitiveFieldSize(type);
+        } else {
+          f.setAccessible(true);
+          referenceFields.add(f);
+          fieldsSize += referenceSize;
+        }
+      }
+      final Class<?> superClass = clazz.getSuperclass();
+      if (superClass != null) {
+        final ClassSizeInfo superClassInfo = classSizeInfos.getUnchecked(superClass);
+        fieldsSize += roundTo(superClassInfo.fieldsSize, superclassFieldPadding);
+        referenceFields.addAll(Arrays.asList(superClassInfo.referenceFields));
+      }
+      this.fieldsSize = fieldsSize;
+      this.objectSize = roundTo(objectHeaderSize + fieldsSize, objectPadding);
+      this.referenceFields = referenceFields.toArray(
+          new Field[referenceFields.size()]);
+    }
+
+    void visit(Object obj, ObjectSizeCalculator calc) {
+      calc.increaseSize(objectSize);
+      enqueueReferencedObjects(obj, calc);
+    }
+
+    public void enqueueReferencedObjects(Object obj, ObjectSizeCalculator calc) {
+      for (Field f : referenceFields) {
+        try {
+          calc.enqueue(f.get(obj));
+        } catch (IllegalAccessException e) {
+          final AssertionError ae = new AssertionError(
+              "Unexpected denial of access to " + f);
+          ae.initCause(e);
+          throw ae;
+        }
+      }
+    }
+  }
+
+  private static long getPrimitiveFieldSize(Class<?> type) {
+    if (type == boolean.class || type == byte.class) {
+      return 1;
+    }
+    if (type == char.class || type == short.class) {
+      return 2;
+    }
+    if (type == int.class || type == float.class) {
+      return 4;
+    }
+    if (type == long.class || type == double.class) {
+      return 8;
+    }
+    throw new AssertionError("Encountered unexpected primitive type " +
+        type.getName());
+  }
+
+  @VisibleForTesting
+  static MemoryLayoutSpecification getEffectiveMemoryLayoutSpecification() {
+    final String vmName = System.getProperty("java.vm.name");
+    if (vmName == null || !(vmName.startsWith("Java HotSpot(TM) ")
+        || vmName.startsWith("OpenJDK") || vmName.startsWith("TwitterJDK"))) {
+      throw new UnsupportedOperationException(
+          "ObjectSizeCalculator only supported on HotSpot VM");
+    }
+
+    final String dataModel = System.getProperty("sun.arch.data.model");
+    if ("32".equals(dataModel)) {
+      // Running with 32-bit data model
+      return new MemoryLayoutSpecification() {
+        @Override public int getArrayHeaderSize() {
+          return 12;
+        }
+        @Override public int getObjectHeaderSize() {
+          return 8;
+        }
+        @Override public int getObjectPadding() {
+          return 8;
+        }
+        @Override public int getReferenceSize() {
+          return 4;
+        }
+        @Override public int getSuperclassFieldPadding() {
+          return 4;
+        }
+      };
+    } else if (!"64".equals(dataModel)) {
+      throw new UnsupportedOperationException("Unrecognized value '" +
+          dataModel + "' of sun.arch.data.model system property");
+    }
+
+    final String strVmVersion = System.getProperty("java.vm.version");
+    final int vmVersion = Integer.parseInt(strVmVersion.substring(0,
+        strVmVersion.indexOf('.')));
+    if (vmVersion >= 17) {
+      long maxMemory = 0;
+      for (MemoryPoolMXBean mp : ManagementFactory.getMemoryPoolMXBeans()) {
+        maxMemory += mp.getUsage().getMax();
+      }
+      if (maxMemory < 30L * 1024 * 1024 * 1024) {
+        // HotSpot 17.0 and above use compressed OOPs below 30GB of RAM total
+        // for all memory pools (yes, including code cache).
+        return new MemoryLayoutSpecification() {
+          @Override public int getArrayHeaderSize() {
+            return 16;
+          }
+          @Override public int getObjectHeaderSize() {
+            return 12;
+          }
+          @Override public int getObjectPadding() {
+            return 8;
+          }
+          @Override public int getReferenceSize() {
+            return 4;
+          }
+          @Override public int getSuperclassFieldPadding() {
+            return 4;
+          }
+        };
+      }
+    }
+
+    // In other cases, it's a 64-bit uncompressed OOPs object model
+    return new MemoryLayoutSpecification() {
+      @Override public int getArrayHeaderSize() {
+        return 24;
+      }
+      @Override public int getObjectHeaderSize() {
+        return 16;
+      }
+      @Override public int getObjectPadding() {
+        return 8;
+      }
+      @Override public int getReferenceSize() {
+        return 8;
+      }
+      @Override public int getSuperclassFieldPadding() {
+        return 8;
+      }
+    };
+  }
+}

--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -108,6 +108,8 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
   def batchSize: Option[Int] =
     if (config.get(BATCH_SIZE).isDefined) Some(config(BATCH_SIZE).toInt) else None
 
+  def batchSizeType: Option[String] = config.get(BATCH_SIZE_TYPE)
+
   def useCursorMarks: Option[Boolean] =
     if (config.get(USE_CURSOR_MARKS).isDefined) Some(config(USE_CURSOR_MARKS).toBoolean) else None
 
@@ -283,6 +285,9 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
     }
     if (batchSize.isDefined) {
       sb ++= s", ${BATCH_SIZE}=${batchSize.get}"
+    }
+    if (batchSizeType.isDefined) {
+      sb ++= s", ${BATCH_SIZE_TYPE}=${batchSizeType.get}"
     }
     if (getChildDocFieldName.isDefined) {
       sb ++= s", ${CHILD_DOC_FIELDNAME}=${getChildDocFieldName.get}"

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -670,6 +670,7 @@ class SolrRelation(
     }
 
     val batchSize: Int = if (conf.batchSize.isDefined) conf.batchSize.get else 1000
+    val batchSizeType: BatchSizeType = if (conf.batchSizeType.isDefined) BatchSizeType.valueOf(conf.batchSizeType.get) else BatchSizeType.NUM_DOCS
 
     // Convert RDD of rows in to SolrInputDocuments
     val uk = SolrQuerySupport.getUniqueKey(zkHost, collectionId)
@@ -680,7 +681,7 @@ class SolrRelation(
     val accName = if (conf.getAccumulatorName.isDefined) conf.getAccumulatorName.get else "Records Written"
     sparkSession.sparkContext.register(acc, accName)
     SparkSolrAccumulatorContext.add(accName, acc.id)
-    SolrSupport.indexDocs(zkHost, collectionId, batchSize, docs, conf.commitWithin, Some(acc))
+    SolrSupport.indexDocs(zkHost, collectionId, batchSize, batchSizeType, docs, conf.commitWithin, Some(acc))
     logger.info("Written {} documents to Solr collection {}", acc.value, collectionId)
   }
 

--- a/src/main/scala/com/lucidworks/spark/example/ml/MLPipelineScala.scala
+++ b/src/main/scala/com/lucidworks/spark/example/ml/MLPipelineScala.scala
@@ -156,7 +156,7 @@ class MLPipelineScala extends SparkApp.RDDProcessor {
                           |${metrics.confusionMatrix}\n""".stripMargin)
 
     // compute the false positive rate per label
-    println(s"""\nF-Measure: ${metrics.fMeasure}
+    println(s"""\nAccuracy: ${metrics.accuracy}
                           |label\tfpr\n""".stripMargin)
     val labels = labelConverter.getLabels
     for (i <- labels.indices)

--- a/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
+++ b/src/main/scala/com/lucidworks/spark/util/ConfigurationConstants.scala
@@ -1,5 +1,7 @@
 package com.lucidworks.spark.util
 
+import com.lucidworks.spark.BatchSizeType
+
 // This should only be used for config options for the sql statements [SolrRelation]
 object ConfigurationConstants {
   val SOLR_ZK_HOST_PARAM: String = "zkhost"
@@ -26,6 +28,8 @@ object ConfigurationConstants {
   // Index params
   val SOFT_AUTO_COMMIT_SECS: String = "soft_commit_secs"
   val BATCH_SIZE: String = "batch_size"
+  // num_docs or num_bytes
+  val BATCH_SIZE_TYPE: String = "batch_size_type"
   val GENERATE_UNIQUE_KEY: String = "gen_uniq_key"
   val GENERATE_UNIQUE_CHILD_KEY: String = "gen_uniq_child_key"
   val COMMIT_WITHIN_MILLI_SECS: String = "commit_within"

--- a/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
+++ b/src/main/scala/com/lucidworks/spark/util/SolrRelationUtil.scala
@@ -637,11 +637,15 @@ object SolrRelationUtil extends LazyLogging {
               val fieldValues = solrDocument.getFieldValues(field.name)
               values.add(processMultipleFieldValues(fieldValues, fieldType))
             case map: util.Map[_,_] =>
-              val obj = map.get(field.name).asInstanceOf[Object]
-              val newValue = processFieldValue(obj, fieldType, multiValued = true)
-              newValue match {
-                case arr: Array[_] => values.add(arr)
-                case any => values.add(Array(any))
+              if (map.containsKey(field.name)) {
+                val obj = map.get(field.name).asInstanceOf[Object]
+                val newValue = processFieldValue(obj, fieldType, multiValued = true)
+                newValue match {
+                  case arr: Array[_] => values.add(arr)
+                  case any => values.add(Array(any))
+                    }
+              } else {
+                values.add(None)
               }
           }
         } else {

--- a/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
+++ b/src/test/java/com/lucidworks/spark/RDDProcessorTestBase.java
@@ -5,7 +5,6 @@ import com.lucidworks.spark.util.SolrSupport;
 import org.apache.solr.common.SolrDocument;
 import org.apache.solr.common.SolrInputDocument;
 import org.apache.solr.util.DateMathParser;
-import org.apache.spark.SparkConf;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.Function;
@@ -15,10 +14,7 @@ import org.junit.BeforeClass;
 
 import java.io.File;
 import java.io.Serializable;
-import java.time.Instant;
 import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
 
 import static org.junit.Assert.assertTrue;
 
@@ -29,6 +25,8 @@ public class RDDProcessorTestBase extends TestSolrCloudClusterSupport implements
 
   protected static transient JavaSparkContext jsc;
   protected static transient SparkSession sparkSession;
+  protected int batchSize = 1000;
+  protected BatchSizeType batchSizeType = BatchSizeType.NUM_DOCS;
 
   public JavaSparkContext getJsc() {
     return jsc;
@@ -130,7 +128,7 @@ public class RDDProcessorTestBase extends TestSolrCloudClusterSupport implements
         return doc;
       }
     });
-    SolrSupport.indexDocs(zkHost, collection, 1000, docs.rdd());
+    SolrSupport.indexDocs(zkHost, collection, batchSize, batchSizeType, docs.rdd());
     return inputDocs.length;
   }
 }

--- a/src/test/java/com/lucidworks/spark/SolrRelationTest.java
+++ b/src/test/java/com/lucidworks/spark/SolrRelationTest.java
@@ -238,7 +238,7 @@ public class SolrRelationTest extends RDDProcessorTestBase {
         options.put(SOLR_COLLECTION_PARAM(), testCollection);
 
         Dataset df = sparkSession.read().format("solr").options(options).load();
-        df.registerTempTable("events");
+        df.createOrReplaceTempView("events");
         sparkSession.sql("SELECT * FROM events").take(1);
 
         sparkSession.sql("SELECT `params.title_s` from events").take(2);
@@ -331,7 +331,7 @@ public class SolrRelationTest extends RDDProcessorTestBase {
 
       Dataset df = sparkSession.read().format("solr").options(options).load();
       df.show();
-      df.registerTempTable(testCollection);
+      df.createOrReplaceTempView(testCollection);
       validateSchema(df);
       //df.show();
 

--- a/src/test/java/com/lucidworks/spark/SolrSqlTest.java
+++ b/src/test/java/com/lucidworks/spark/SolrSqlTest.java
@@ -43,7 +43,7 @@ public class SolrSqlTest extends RDDProcessorTestBase {
 
       {
         Dataset eventsim = sparkSession.read().format("solr").options(options).option(SOLR_DOC_VALUES(), "true").load();
-        eventsim.registerTempTable("eventsim");
+        eventsim.createOrReplaceTempView("eventsim");
 
         Dataset records = sparkSession.sql("SELECT * FROM eventsim");
         StructType schema = records.schema();
@@ -66,7 +66,7 @@ public class SolrSqlTest extends RDDProcessorTestBase {
       // Filter using SQL syntax and escape field names
       {
         Dataset eventsim = sparkSession.read().format("solr").options(options).load();
-        eventsim.registerTempTable("eventsim");
+        eventsim.createOrReplaceTempView("eventsim");
 
         Dataset records = sparkSession.sql("SELECT `userId`, `ts` from eventsim WHERE `gender` = 'M'");
         assert records.count() == 567;

--- a/src/test/java/com/lucidworks/spark/TestSolrCloudClusterSupport.java
+++ b/src/test/java/com/lucidworks/spark/TestSolrCloudClusterSupport.java
@@ -94,7 +94,9 @@ public class TestSolrCloudClusterSupport {
     cluster = new MiniSolrCloudCluster(1, null /* hostContext */,
             testWorkingDir.toPath(), solrXmlContents, extraServlets, null);
 
-    cloudSolrServer = new CloudSolrClient.Builder().withZkHost(cluster.getZkServer().getZkAddress()).sendUpdatesOnlyToShardLeaders().build();
+    final List<String> zkHosts = Collections.singletonList(cluster.getZkServer().getZkAddress());
+    final Optional<String> zkChroot = Optional.empty();
+    cloudSolrServer = new CloudSolrClient.Builder(zkHosts, zkChroot).sendUpdatesOnlyToShardLeaders().build();
     cloudSolrServer.connect();
 
     assertTrue(!cloudSolrServer.getZkStateReader().getClusterState().getLiveNodes().isEmpty());

--- a/src/test/java/com/lucidworks/spark/TestSolrCloudClusterSupport.java
+++ b/src/test/java/com/lucidworks/spark/TestSolrCloudClusterSupport.java
@@ -24,7 +24,6 @@ import org.junit.BeforeClass;
 import org.junit.AfterClass;
 import org.noggit.CharArr;
 import org.noggit.JSONWriter;
-import org.restlet.ext.servlet.ServerServlet;
 import org.scalatest.FunSuite;
 
 import static org.junit.Assert.assertNotNull;
@@ -87,9 +86,6 @@ public class TestSolrCloudClusterSupport {
 
     // need the schema stuff
     final SortedMap<ServletHolder,String> extraServlets = new TreeMap<ServletHolder,String>();
-    final ServletHolder solrSchemaRestApi = new ServletHolder("SolrSchemaRestApi", ServerServlet.class);
-    solrSchemaRestApi.setInitParameter("org.restlet.application", "org.apache.solr.rest.SolrSchemaRestApi");
-    extraServlets.put(solrSchemaRestApi, "/schema/*");
 
     cluster = new MiniSolrCloudCluster(1, null /* hostContext */,
             testWorkingDir.toPath(), solrXmlContents, extraServlets, null);

--- a/src/test/java/com/lucidworks/spark/example/streaming/BasicIndexingTest.java
+++ b/src/test/java/com/lucidworks/spark/example/streaming/BasicIndexingTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.util.Arrays;
 import java.util.concurrent.LinkedBlockingDeque;
 
+import com.lucidworks.spark.BatchSizeType;
 import com.lucidworks.spark.StreamProcessorTestBase;
 import com.lucidworks.spark.rdd.SolrJavaRDD;
 import com.lucidworks.spark.util.SolrSupport;
@@ -63,7 +64,7 @@ public class BasicIndexingTest extends StreamProcessorTestBase {
 
     // Send to Solr
     String zkHost = cluster.getZkServer().getZkAddress();
-    SolrSupport.indexDStreamOfDocs(zkHost, testCollection, 1, docs.dstream());
+    SolrSupport.indexDStreamOfDocs(zkHost, testCollection, 1, BatchSizeType.NUM_DOCS, docs.dstream());
 
     // Actually start processing the stream here ...
     jssc.start();

--- a/src/test/java/com/lucidworks/spark/solr/TestEmbeddedSolrServer.java
+++ b/src/test/java/com/lucidworks/spark/solr/TestEmbeddedSolrServer.java
@@ -1,5 +1,6 @@
 package com.lucidworks.spark.solr;
 
+import com.lucidworks.spark.BatchSizeType;
 import com.lucidworks.spark.RDDProcessorTestBase;
 import com.lucidworks.spark.util.EmbeddedSolrServerFactory;
 import org.apache.solr.client.solrj.SolrQuery;
@@ -10,15 +11,27 @@ import org.junit.Test;
 public class TestEmbeddedSolrServer extends RDDProcessorTestBase {
 
   @Test
-  public void testEmbeddedSolrServer() throws Exception {
-    String testCollection = "testEmbeddedSolrServer";
+  public void testEmbeddedSolrServerUseNumDocsAsBatchSize() throws Exception {
+    this.batchSizeType = BatchSizeType.NUM_DOCS;
+    this.batchSize = 3; // 3 docs
+    runEmbeddedServerTest("batchNumDocs", 10);
+  }
+
+  @Test
+  public void testEmbeddedSolrServerUseNumBytesAsBatchSize() throws Exception {
+    this.batchSizeType = BatchSizeType.NUM_BYTES;
+    this.batchSize = 1000; // 1000 bytes
+    runEmbeddedServerTest("batchNumBytes", 100);
+  }
+
+  private void runEmbeddedServerTest(String testCollection, int numDocs) throws Exception {
     EmbeddedSolrServer embeddedSolrServer = null;
     try {
       String zkHost = cluster.getZkServer().getZkAddress();
-      buildCollection(zkHost, testCollection, 10, 1);
+      buildCollection(zkHost, testCollection, numDocs, 1);
       embeddedSolrServer = EmbeddedSolrServerFactory.singleton.getEmbeddedSolrServer(zkHost, testCollection);
       QueryResponse queryResponse = embeddedSolrServer.query(new SolrQuery("*:*"));
-      assert(queryResponse.getStatus() == 0);
+      assert (queryResponse.getStatus() == 0);
     } finally {
       if (embeddedSolrServer != null) {
         embeddedSolrServer.close();

--- a/src/test/java/com/lucidworks/spark/util/EventsimUtil.java
+++ b/src/test/java/com/lucidworks/spark/util/EventsimUtil.java
@@ -32,7 +32,7 @@ public class EventsimUtil {
     // Modify the unix timestamp to ISO format for Solr
     log.info("Indexing eventsim documents from file " + datasetPath);
 
-    df.registerTempTable("jdbcDF");
+    df.createOrReplaceTempView("jdbcDF");
     sparkSession.udf().register("ts2iso", new UDF1<Long, Timestamp>() {
       public Timestamp call(Long ts) {
         return asDate(ts);

--- a/src/test/resources/conf/solrconfig.xml
+++ b/src/test/resources/conf/solrconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <config>
-  <luceneMatchVersion>6.4.2</luceneMatchVersion>
+  <luceneMatchVersion>LATEST</luceneMatchVersion>
   <dataDir>${solr.data.dir:}</dataDir>
   <directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.NRTCachingDirectoryFactory}"/>
   <codecFactory class="solr.SchemaCodecFactory"/>

--- a/src/test/resources/custom-solrconfig.xml
+++ b/src/test/resources/custom-solrconfig.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <config>
-    <luceneMatchVersion>7.5.0</luceneMatchVersion>
+    <luceneMatchVersion>LATEST</luceneMatchVersion>
     <dataDir>${solr.data.dir:}</dataDir>
     <directoryFactory name="DirectoryFactory" class="solr.RAMDirectoryFactory"/>
     <codecFactory class="solr.SchemaCodecFactory"/>

--- a/src/test/scala/com/lucidworks/spark/TestFramework.scala
+++ b/src/test/scala/com/lucidworks/spark/TestFramework.scala
@@ -13,7 +13,6 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.udf
 import org.eclipse.jetty.servlet.ServletHolder
 import org.junit.Assert._
-import org.restlet.ext.servlet.ServerServlet
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 
 trait SolrCloudTestBuilder extends BeforeAndAfterAll with LazyLogging { this: Suite =>
@@ -40,10 +39,6 @@ trait SolrCloudTestBuilder extends BeforeAndAfterAll with LazyLogging { this: Su
 
     // need the schema stuff
     val extraServlets: java.util.SortedMap[ServletHolder, String] = new java.util.TreeMap[ServletHolder, String]()
-
-    val solrSchemaRestApi : ServletHolder = new ServletHolder("SolrSchemaRestApi", classOf[ServerServlet])
-    solrSchemaRestApi.setInitParameter("org.restlet.application", "org.apache.solr.rest.SolrSchemaRestApi")
-    extraServlets.put(solrSchemaRestApi, "/schema/*")
 
     cluster = new MiniSolrCloudCluster(1, null /* hostContext */,
       testWorkingDir.toPath, solrXmlContents, extraServlets, null /* extra filters */)

--- a/src/test/scala/com/lucidworks/spark/TestQuerying.scala
+++ b/src/test/scala/com/lucidworks/spark/TestQuerying.scala
@@ -11,12 +11,13 @@ class TestQuerying extends TestSuiteBuilder {
 
   test("Solr version") {
     val solrVersion = SolrSupport.getSolrVersion(zkHost)
-    assert(solrVersion == "8.4.1")
+    assert(solrVersion == "8.8.2")
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 7, 5, 0))
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 7, 3, 0))
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 7, 1, 0))
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 8, 0, 0))
     assert(SolrSupport.isSolrVersionAtleast(solrVersion, 8, 1, 0))
+    // TODO: add more here?
     assert(!SolrSupport.isSolrVersionAtleast(solrVersion, 9, 0, 0))
   }
 


### PR DESCRIPTION
PR for 3.9.0 release

* check to make sure that the results map contains the field as a key before processing that field https://github.com/lucidworks/spark-solr/pull/295
* replace deprecated API use in TestSolrCloudClusterSupport https://github.com/lucidworks/spark-solr/pull/310
* replace deprecated org.apache.spark API use (in examples and tests) https://github.com/lucidworks/spark-solr/pull/311
* use LATEST luceneMatchVersion in test/resources https://github.com/lucidworks/spark-solr/pull/312
* upgrade to Apache Solr 8.8.2 https://github.com/lucidworks/spark-solr/pull/313
* add a "batchSizeType" parameter so that you can choose to have Solr b… https://github.com/lucidworks/spark-solr/pull/314
