### PR TITLE
replace deprecated org.apache.solr.client.solrj.io.Tuple.getMap() API use

### DIFF
--- a/src/main/java/com/lucidworks/spark/query/TupleStreamIterator.java
+++ b/src/main/java/com/lucidworks/spark/query/TupleStreamIterator.java
@@ -100,7 +100,7 @@ public abstract class TupleStreamIterator extends ResultsIterator<Map> {
     currentTuple = null;
     ++numDocs;
     increment();
-    return tempCurrentTuple.getMap();
+    return tempCurrentTuple.getFields();
   }
 
   public synchronized Map next() {


### PR DESCRIPTION
javadoc link: https://solr.apache.org/docs/8_8_2/solr-solrj/org/apache/solr/client/solrj/io/Tuple.html#getMap--