### PR TITLE
change Solr metrics collection default (from true to false)

### DIFF
--- a/src/main/resources/embedded/solr.xml
+++ b/src/main/resources/embedded/solr.xml
@@ -5,4 +5,5 @@
     <int name="socketTimeout">${socketTimeout:0}</int>
     <int name="connTimeout">${connTimeout:0}</int>
   </shardHandlerFactory>
+  <metrics enabled="${metricsEnabled:false}"/>
 </solr>

--- a/src/test/resources/solr.xml
+++ b/src/test/resources/solr.xml
@@ -22,5 +22,7 @@
     <int name="connTimeout">${connTimeout:15000}</int>
   </shardHandlerFactory>
 
+  <metrics enabled="${metricsEnabled:false}"/>
+
 </solr>
 


### PR DESCRIPTION
This pull request proposes to change the Solr metrics collection default from `true` to `false` and to provide an option to override via `-DmetricsEnabled=true` on the command line.

* for the spark-solr use case Solr metrics collection and metrics use may (and I'm speculating here) not be as common or useful as for a solr Solr use case

* metrics collection can be disabled as documented at https://solr.apache.org/guide/8_8/metrics-reporting.html#disabling-the-metrics-collection

* if metrics collection is disabled then as per https://github.com/apache/lucene-solr/blob/releases/lucene-solr/8.8.2/solr/core/src/java/org/apache/solr/core/CoreContainer.java#L752-L756 code snippet no `MetricsCollectorHandler` object is created

* from Apache Solr 8.9.0 onwards the `MetricsCollectorHandler` class is deprecated as per https://solr.apache.org/docs/8_9_0/solr-core/org/apache/solr/handler/admin/MetricsCollectorHandler.html
  * #326 is separately re: upgrading from 8.8.2 to 8.9.0 version