### PR TITLE
FUS-3017: Spark-Solr performance improvements

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -261,7 +261,7 @@ Keep in mind that this is only a hint to the split calculator and you may end up
 
 Usage: `option("splits_per_shard", "30")`
 
-Default: default value is calculated automatically based on the number of docs for Solr query
+Default: 1
 
 ==== flatten_multivalued
 

--- a/src/main/scala/com/lucidworks/spark/SolrConf.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrConf.scala
@@ -91,7 +91,7 @@ class SolrConf(config: Map[String, String]) extends Serializable with LazyLoggin
     if (config.contains(SOLR_DOC_VALUES)) Some(config(SOLR_DOC_VALUES).toBoolean) else None
 
   def getSplitsPerShard: Option[Int] =
-    if (config.contains(SOLR_SPLITS_PER_SHARD_PARAM)) Some(config(SOLR_SPLITS_PER_SHARD_PARAM).toInt) else None
+    if (config.contains(SOLR_SPLITS_PER_SHARD_PARAM)) Some(config(SOLR_SPLITS_PER_SHARD_PARAM).toInt) else Some(1)
 
   def escapeFieldNames: Option[Boolean] =
     if (config.contains(ESCAPE_FIELDNAMES_PARAM)) Some(config(ESCAPE_FIELDNAMES_PARAM).toBoolean) else None

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -871,30 +871,6 @@ object SolrRelation extends LazyLogging {
     //Always sort on _version_ asc
     query.addSort("_version_", SolrQuery.ORDER.asc)
     return
-
-    //Dead code below, but leaving in case we want to bring it back to life.
-    // if doc values enabled for the uniqueKey field, use that for sorting
-    if (baseSchema.fieldNames.contains(uniqueKey)) {
-      if (baseSchema(uniqueKey).metadata.getBoolean("docValues")) {
-        query.addSort(uniqueKey, SolrQuery.ORDER.asc)
-        return
-      }
-    }
-
-    querySchema.fields.foreach(field => {
-      val solrFieldName = if (field.metadata.contains("name")) field.metadata.getString("name") else field.name
-      // The field only contains 'multiValued' in the schema if 'flattenMultivalued' is false (it is true by default)
-      // Hence, this is not always reliable. It is possible a multiValued field ends up being a sort field
-      if (field.metadata.contains("multiValued")) {
-        if (!field.metadata.getBoolean("multiValued")) {
-          query.addSort(solrFieldName, SolrQuery.ORDER.asc)
-          return
-        }
-      } else {
-        query.addSort(solrFieldName, SolrQuery.ORDER.asc)
-        return
-      }
-    })
   }
 
   def parseSortParamFromString(sortParam: String):  List[SortClause] = {

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -871,7 +871,7 @@ object SolrRelation extends LazyLogging {
     //Always sort on _version_ asc
     query.addSort("_version_", SolrQuery.ORDER.asc)
     return
-    
+
     //Dead code below, but leaving in case we want to bring it back to life.
     // if doc values enabled for the uniqueKey field, use that for sorting
     if (baseSchema.fieldNames.contains(uniqueKey)) {

--- a/src/main/scala/com/lucidworks/spark/SolrRelation.scala
+++ b/src/main/scala/com/lucidworks/spark/SolrRelation.scala
@@ -867,6 +867,12 @@ object SolrRelation extends LazyLogging {
   }
 
   def addSortField(baseSchema: StructType, querySchema: StructType, query: SolrQuery, uniqueKey: String): Unit = {
+
+    //Always sort on _version_ asc
+    query.addSort("_version_", SolrQuery.ORDER.asc)
+    return
+    
+    //Dead code below, but leaving in case we want to bring it back to life.
     // if doc values enabled for the uniqueKey field, use that for sorting
     if (baseSchema.fieldNames.contains(uniqueKey)) {
       if (baseSchema(uniqueKey).metadata.getBoolean("docValues")) {

--- a/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
+++ b/src/main/scala/com/lucidworks/spark/rdd/StreamingSolrRDD.scala
@@ -20,7 +20,7 @@ class StreamingSolrRDD(
     fields: Option[Array[String]] = None,
     rows: Option[Int] = Option(DEFAULT_PAGE_SIZE),
     splitField: Option[String] = None,
-    splitsPerShard: Option[Int] = None,
+    splitsPerShard: Option[Int] = Some(1),
     solrQuery: Option[SolrQuery] = None,
     uKey: Option[String] = None,
     val accumulator: Option[SparkSolrAccumulator] = None)

--- a/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
+++ b/src/test/scala/com/lucidworks/spark/EventsimTestSuite.scala
@@ -145,8 +145,7 @@ class EventsimTestSuite extends EventsimBuilder {
       SOLR_DO_SPLITS -> "true"
     )
     val df: DataFrame = sparkSession.read.format("solr").options(options).load()
-    assert(df.rdd.getNumPartitions > numShards)
-    assert(df.rdd.getNumPartitions == 4)
+    assert(df.rdd.getNumPartitions == numShards)
   }
 
   test("SQL query splits with export handler") {
@@ -386,7 +385,7 @@ class EventsimTestSuite extends EventsimBuilder {
 
     solrRelation.initialQuery.setSorts(Collections.emptyList())
     SolrRelation.addSortField(solrRelation.baseSchema.get, querySchema, solrRelation.initialQuery, solrRelation.uniqueKey)
-    assert(solrRelation.initialQuery.getSorts == Collections.singletonList(new SortClause(solrRelation.uniqueKey, SolrQuery.ORDER.asc)))
+    assert(solrRelation.initialQuery.getSorts == Collections.singletonList(new SortClause("_version_", SolrQuery.ORDER.asc)))
   }
 
   test("Test dynamic extensions") {


### PR DESCRIPTION
There are two small changes in Spark-Solr that will have a big impact on performance and usability. 

1. Set the default splits_per_shard to 1. By default if splits_per_shard is not set spark-solr uses a formula to compute splits_per_shard which can create a huge number of splits which will grind the cluster to a halt. Having the default behavior result in a trap is very detrimental to usability. It's very difficult for the typical user to understand the effect of splits_per_shard so the safest approach is to simply default to 1. Users can experiment with increasing this number to see if it improves performance or causes problems.

2. Change the default export handler sort field from id to `_version_ `. Spark does not utilize the sort order anyway so spark-solr should simply sort on the most performant field. `_version_` is a long type which is much more efficient to sort on then the id which is a string.

